### PR TITLE
Fixes Incorrect Class Version

### DIFF
--- a/inc/plugins/MyAlerts/Alerts.class.php
+++ b/inc/plugins/MyAlerts/Alerts.class.php
@@ -9,7 +9,7 @@
 
 class Alerts
 {
-    const VERSION = '1.02';
+    const VERSION = '1.04';
     private $mybb = null;
     private $db = null;
 


### PR DESCRIPTION
An error is displayed upon install and doesn't allow the admin to activate until the version # is changed in the Class file.
