### PR TITLE
Language Issue Work-around (not to be pulled)

### DIFF
--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -931,7 +931,15 @@ function myalerts_page()
                     //  variable variables. What fun! http://php.net/manual/en/language.variables.variable.php
                     $tempkey = 'myalerts_setting_'.$key;
 
-                    $langline = $lang->$tempkey;
+                    // if this isn't a core alert type and the language isn't already loaded . . .
+					if(!$lang->$key && !in_array($key, array('rep', 'pm', 'buddylist', 'quoted', 'post_threadauthor')))
+					{
+						// load the plugin's language
+						@$lang->load($key);
+					}
+
+					// use out tempkey to store the correct language line
+					$langline = $lang->$tempkey;
 
                     $checked = '';
                     if ($value) {


### PR DESCRIPTION
I added a check for the language of the plugin module and if not a core alert type it loads that language.

This is a work-around (tested and works fine) but assumes that the language file exists and is named the same as the alert type.

I am not trying to introduce this as an actual solution, but rather hilight the issue.
