### PR TITLE
Fixed a critical typing mistake

### DIFF
--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -457,7 +457,7 @@ function myalerts_register_do_end()
             'value'      => 1,
         );
     }
-    $db->inset_query_multiple('alert_setting_values', $userSettings);
+    $db->insert_query_multiple('alert_setting_values', $userSettings);
 
 }
 


### PR DESCRIPTION
There was a typo which won't let users register properly.

$db->inset_query_multiple turns into $db->insert_query_multiple and make registration working again.
