### PR TITLE
Delete user's custom alert settings when deleted

### DIFF
--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -1129,3 +1129,13 @@ function myalerts_xmlhttp()
         $Alerts->markRead($toMarkRead);
     }
 }
+
+$plugins->add_hook('admin_user_users_delete_commit', 'myalerts_user_delete');
+
+function myalerts_user_delete()
+{
+    global $db, $user;
+	$db->delete_query("alert_setting_values", "user_id='{$user['uid']}'");
+}
+
+?>


### PR DESCRIPTION
The users custom alerts settings are currently not deleted when the user is deleted.
The only place I can think of a user being deleted is the Admin CP.
Originally suggested [here](http://community.mybb.com/thread-119331-post-979199.html#pid979199) by [Qub1](http://community.mybb.com/user-61272.html).
