### PR TITLE
Adds post title to quoted alert message

### DIFF
--- a/inc/languages/english/myalerts.lang.php
+++ b/inc/languages/english/myalerts.lang.php
@@ -19,7 +19,7 @@ $l['myalerts_no_new_alerts'] = 'You have no new alerts.';
 $l['myalerts_rep'] = '{1} modified <a href="reputation.php?uid={2}">your reputation</a>. ({3})';
 $l['myalerts_pm'] = '{1} sent you a new private message titled "{2}". ({3})';
 $l['myalerts_buddylist'] = '{1} added you to their buddy list. ({2})';
-$l['myalerts_quoted'] = '{1} quoted you in <a href="{2}">a post</a>. ({3})';
+$l['myalerts_quoted'] = '{1} quoted you in <a href="{2}">{3}</a>. ({4})';
 $l['myalerts_post_threadauthor'] = '{1} replied to your thread "<a href="{2}">{3}</a>". There may be more posts after this. ({4})';
 
 $l['myalerts_setting_rep'] = 'Receive alert for reputation?';

--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -433,7 +433,7 @@ function parse_alert($alert)
         $alert['rowType'] = 'buddylistAlert';
     } elseif ($alert['alert_type'] == 'quoted' AND $mybb->settings['myalerts_alert_quoted']) {
         $alert['postLink'] = $mybb->settings['bburl'].'/'.get_post_link($alert['content']['pid'], $alert['content']['tid']).'#pid'.$alert['content']['pid'];
-        $alert['message'] = $lang->sprintf($lang->myalerts_quoted, $alert['user'], $alert['postLink'], $alert['dateline']);
+        $alert['message'] = $lang->sprintf($lang->myalerts_quoted, $alert['user'], $alert['postLink'], htmlspecialchars_uni($parser->parse_badwords($alert['content']['subject'])), $alert['dateline']);
         $alert['rowType'] = 'quotedAlert';
     } elseif ($alert['alert_type'] == 'post_threadauthor' AND $mybb->settings['myalerts_alert_post_threadauthor']) {
         $alert['threadLink'] = $mybb->settings['bburl'].'/'.get_thread_link($alert['content']['tid'], 0, 'newpost');


### PR DESCRIPTION
Small modification that changes the quoted notification from 'quoted in a post' to 'quoted in ', to give more context before following the link.
This was origninaly submited to the MyAlerts/MyAlerts repo which is not the base.
Might be worth deleting that fork.
