### PR TITLE
Avoiding multiple (annoying) alerts for non-core alert types

### DIFF
--- a/inc/plugins/MyAlerts/Alerts.class.php
+++ b/inc/plugins/MyAlerts/Alerts.class.php
@@ -187,6 +187,25 @@ class Alerts
     public function addAlert($uid, $type = '', $tid = 0, $from = 0, $content = array(), $forced = 0)
     {
         $content = json_encode($content);
+        
+        // first of all, start the session if not started yet
+        if(!session_id()) {
+    		session_start();
+		}
+		
+		if(!empty($tid)) {
+            // if tid and type coincide with the respective ones in the $_SESSION array, then do nothing and save multiple notifications to the user
+			if($tid == $_SESSION['tid'] && $type != $_SESSION['type']) {
+				return;
+			}
+            // there's an unrelated alert here, so unset the previous stored tid and type and store them again, then alert the user as usual
+            else {
+				unset($_SESSION['tid']);
+				unset($_SESSION['type']);
+				$_SESSION['tid'] = $tid;
+				$_SESSION['type'] = $type;
+			}
+		}
 
         $insertArray = array(
             'uid'        => (int) $uid,


### PR DESCRIPTION
As discussed [here](http://community.mybb.com/post-1001311.html#pid1001311), if you're using an extra pack of alerts or whatever plugin that supports MyAlerts, users can receive more than one notification for the same event. If you are a) mentioned, b) quoted in a c) reply of a thread you've made and d) you've subscribed to, MyAlerts will send you 4 alerts with the same purpose, assuming you've installed MentionMe + Plugins Alerts Pack.

This came up to my mind just now after months. I was looking for something to improve my MyAlerts extensions and got the solution scratching my head a little bit. It's quite easy but really effective as we can make a great use of PHP sessions to store subsequent calls and data to check whether if an alert has been already delivered for that specific thread or not and act dependently on it.

```
        if(!session_id()) {
            session_start();
        }

        if(!empty($tid)) {
            if($tid == $_SESSION['tid'] && $type != $_SESSION['type']) {
                return;
            } else {
                unset($_SESSION['tid']);
                unset($_SESSION['type']);
                $_SESSION['tid'] = $tid;
                $_SESSION['type'] = $type;
            }
        }
```

It's just easy as this snippet. We check for both the tid and the type of alert because if you reply to a thread, the user sees the alert and you reply once again to the same thread, the tid will be the same and the alert won't be generated (we want at least one to be delivered :smile:).

This seems the best solution with a transparent approach to me. No wasted queries and just a small change to make the MyAlerts experience much smarter for both developers and users.
