### PR TITLE
Make the massager using singleton and remove all uses of $GLOBALS

### DIFF
--- a/admin/modules/config/myalerts.php
+++ b/admin/modules/config/myalerts.php
@@ -31,7 +31,7 @@ function myalerts_acp_manage_alert_types()
 {
     global $mybb, $lang, $page, $db, $cache;
 
-    $alertTypeManager = new MybbStuff_MyAlerts_AlertTypeManager($db, $cache);
+    $alertTypeManager = MybbStuff_MyAlerts_AlertTypeManager::getInstance();
 
     $alertTypes = $alertTypeManager->getAlertTypes();
 

--- a/alerts.php
+++ b/alerts.php
@@ -46,15 +46,15 @@ function myalerts_redirect_alert($mybb, $lang)
     $alertId = $mybb->get_input('id', MyBB::INPUT_INT);
 
     /** @var MybbStuff_MyAlerts_Entity_Alert $alert */
-    $alert = $GLOBALS['mybbstuff_myalerts_alert_manager']->getAlert($alertId);
+    $alert = MybbStuff_MyAlerts_AlertManager::getInstance()->getAlert($alertId);
     /** @var MybbStuff_MyAlerts_Formatter_AbstractFormatter $alertTypeFormatter */
-    $alertTypeFormatter = $GLOBALS['mybbstuff_myalerts_alert_formatter_manager']->getFormatterForAlertType($alert->getType()->getCode());
+    $alertTypeFormatter = MybbStuff_MyAlerts_AlertFormatterManager::getInstance()->getFormatterForAlertType($alert->getType()->getCode());
 
     if (!$alert || !$alertTypeFormatter) {
         error($lang->myalerts_error_alert_not_found);
     }
 
-    $GLOBALS['mybbstuff_myalerts_alert_manager']->markRead(array($alertId));
+    MybbStuff_MyAlerts_AlertManager::getInstance()->markRead(array($alertId));
 
     $redirectLink = unhtmlentities($alertTypeFormatter->buildShowLink($alert));
 
@@ -73,7 +73,7 @@ function myalerts_redirect_alert($mybb, $lang)
  */
 function myalerts_alert_settings($mybb, $db, $lang, $plugins, $templates, $theme)
 {
-	$alertTypes = $GLOBALS['mybbstuff_myalerts_alert_type_manager']->getAlertTypes();
+	$alertTypes = MybbStuff_MyAlerts_AlertTypeManager::getInstance()->getAlertTypes();
 
 	if (strtolower($mybb->request_method) == 'post') { // Saving alert type settings
 		$disabledAlerts = array();
@@ -200,7 +200,7 @@ function myalerts_delete_all_alerts($mybb, $db, $lang)
  */
 function myalerts_view_alerts($mybb, $lang, $templates, $theme)
 {
-    $alerts = $GLOBALS['mybbstuff_myalerts_alert_manager']->getAlerts(0, 10);
+    $alerts = MybbStuff_MyAlerts_AlertManager::getInstance()->getAlerts(0, 10);
 
     if (!$lang->myalerts) {
         $lang->load('myalerts');
@@ -211,7 +211,7 @@ function myalerts_view_alerts($mybb, $lang, $templates, $theme)
     require_once __DIR__ . '/inc/functions_user.php';
     usercp_menu();
 
-    $numAlerts = $GLOBALS['mybbstuff_myalerts_alert_manager']->getNumAlerts();
+    $numAlerts = MybbStuff_MyAlerts_AlertManager::getInstance()->getNumAlerts();
     $page      = (int) $mybb->input['page'];
     $pages     = ceil($numAlerts / $mybb->settings['myalerts_perpage']);
 
@@ -227,7 +227,7 @@ function myalerts_view_alerts($mybb, $lang, $templates, $theme)
     }
     $multipage = multipage($numAlerts, $mybb->settings['myalerts_perpage'], $page, "usercp.php?action=alerts");
 
-    $alertsList = $GLOBALS['mybbstuff_myalerts_alert_manager']->getAlerts($start);
+    $alertsList = MybbStuff_MyAlerts_AlertManager::getInstance()->getAlerts($start);
 
     $readAlerts = array();
 
@@ -248,7 +248,7 @@ function myalerts_view_alerts($mybb, $lang, $templates, $theme)
         eval("\$alertsListing = \"" . $templates->get('myalerts_alert_row_no_alerts') . "\";");
     }
 
-    $GLOBALS['mybbstuff_myalerts_alert_manager']->markRead($readAlerts);
+    MybbStuff_MyAlerts_AlertManager::getInstance()->markRead($readAlerts);
 
     global $headerinclude, $header, $footer, $usercpnav;
 

--- a/inc/plugins/MybbStuff/MyAlerts/src/AlertFormatterManager.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/AlertFormatterManager.php
@@ -21,11 +21,27 @@ class MybbStuff_MyAlerts_AlertFormatterManager
      * @var array
      */
     private $alertFormatters;
+    /** @var MybbStuff_MyAlerts_AlertFormatterManager */
+    private static $instance = null;
+
+    public static function createInstance(MyBB $mybb, MyLanguage $lang)
+    {
+        if(static::$instance === null)
+            static::$instance = new self($mybb, $lang);
+        return static::$instance;
+    }
+
+    public static function getInstance()
+    {
+        if(static::$instance === null)
+            return false;
+        return static::$instance;
+    }
 
     /**
      * Create a new formatter manager.
      */
-    public function __construct(MyBB $mybb, MyLanguage $lang)
+    private function __construct(MyBB $mybb, MyLanguage $lang)
     {
         $this->mybb = $mybb;
         $this->lang = $lang;

--- a/inc/plugins/MybbStuff/MyAlerts/src/AlertManager.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/AlertManager.php
@@ -27,6 +27,22 @@ class MybbStuff_MyAlerts_AlertManager
     private $alertTypeManager;
     /** @var array An array of the currently enabled alert types for the user. */
     private $currentUserEnabledAlerts = array();
+    /** @var MybbStuff_MyAlerts_AlertManager */
+    private static $instance = null;
+
+    public static function createInstance($mybb, $db, $cache, MybbStuff_MyAlerts_AlertTypeManager $alertTypeManager)
+    {
+        if(static::$instance === null)
+            static::$instance = new self($mybb, $db, $cache, $alertTypeManager);
+        return static::$instance;
+    }
+
+    public static function getInstance()
+    {
+        if(static::$instance === null)
+            return false;
+        return static::$instance;
+    }
 
     /**
      * Initialise a new instance of the AlertManager.
@@ -38,7 +54,7 @@ class MybbStuff_MyAlerts_AlertManager
      *                                                              types.
      * @param MybbSTuff_MyAlerts_AlertTypeManager $alertTypeManager Alert type manager instance.
      */
-    public function __construct($mybb, $db, $cache, MybbStuff_MyAlerts_AlertTypeManager $alertTypeManager)
+    private function __construct($mybb, $db, $cache, MybbStuff_MyAlerts_AlertTypeManager $alertTypeManager)
     {
         $this->mybb = $mybb;
         $this->db = $db;

--- a/inc/plugins/MybbStuff/MyAlerts/src/AlertTypeManager.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/AlertTypeManager.php
@@ -11,8 +11,24 @@ class MybbStuff_MyAlerts_AlertTypeManager
     private $db;
     /** @var datacache */
     private $cache;
+    /** @var MybbStuff_MyAlerts_AlertTypeManager */
+    private static $instance = null;
 
-    public function __construct(DB_MySQLi $db, datacache $cache)
+    public static function createInstance(DB_MySQLi $db, datacache $cache)
+    {
+        if(static::$instance === null)
+            static::$instance = new self($db, $cache);
+        return static::$instance;
+    }
+
+    public static function getInstance()
+    {
+        if(static::$instance === null)
+            return false;
+        return static::$instance;
+    }
+
+    private function __construct(DB_MySQLi $db, datacache $cache)
     {
         $this->db = $db;
         $this->cache = $cache;


### PR DESCRIPTION
I've added two static functions to the manager classes: `createInstance` which has the same parameters as the constructor has and creates the instance (if none has been so far) and returns it and `getInstance` which returns either the instance or false if none was created so far.
Also renamed `myalerts_initialise_global_objects` to `myalerts_create_instances` where `createInstance` is called for all manager classes. Added the function also to the first hook in the acp to load the functions there.
Finally I've replaced all calls to the globalised classes with calls to the corresponding `getInstance` function.
