### PR TITLE
Encode the url properly

### DIFF
--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -533,7 +533,7 @@ function myalerts_global_intermediate()
             $alerts = eval($templates->render('myalerts_alert_row_popup_no_alerts'));
         }
 
-        $myalerts_return_link = htmlspecialchars_uni(myalerts_get_current_url());
+        $myalerts_return_link = urlencode(myalerts_get_current_url());
 
         $myalerts_headericon = eval($templates->render('myalerts_headericon'));
     }


### PR DESCRIPTION
For example when clicking the delete all link on `mybblog.php?action=view&id=1` the delete link will redirect to `mybblog.php?action=view` as the `&` isn't encoded properly. The url should be completly encoded so all parameters will be added to the redirect url.
