### PR TITLE
Added reply to subscribed thread alert.

### DIFF
--- a/inc/languages/english/myalerts.lang.php
+++ b/inc/languages/english/myalerts.lang.php
@@ -21,12 +21,14 @@ $l['myalerts_pm'] = '{1} sent you a new private message titled "{2}". ({3})';
 $l['myalerts_buddylist'] = '{1} added you to their buddy list. ({2})';
 $l['myalerts_quoted'] = '{1} quoted you in {2}. ({3})';
 $l['myalerts_post_threadauthor'] = '{1} replied to your thread "{2}". There may be more posts after this. ({3})';
+$l['myalerts_subscribed_thread'] = '{1} replied to your subscribed thread "{2}". ({3})';
 
 $l['myalerts_setting_rep'] = 'Receive alert for reputation?';
 $l['myalerts_setting_pm'] = 'Receive alert for Private Message (PM)?';
 $l['myalerts_setting_buddylist'] = 'Receive alert when added to buddylist?';
 $l['myalerts_setting_quoted'] = 'Receive alert when quoted in a post?';
 $l['myalerts_setting_post_threadauthor'] = 'Receive alert when somebody replies to your thread?';
+$l['myalerts_setting_subscribed_thread'] = 'Receive alert when somebody replies to one of your subscribed threads?';
 $l['myalerts_settings_save'] = 'Save Settings';
 $l['myalerts_settings_updated'] = 'Alert settings updated successfully. Redirecting back to settings page.';
 $l['myalerts_settings_updated_title'] = 'Alert Settings Updated.';

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/SubscribedThreadFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/SubscribedThreadFormatter.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Alert formatter for subscribed thread alerts.
+ */
+class MybbStuff_MyAlerts_Formatter_SubscribedThreadFormatter extends MybbStuff_MyAlerts_Formatter_AbstractFormatter
+{
+    /**
+     * Format an alert into it's output string to be used in both the main alerts listing page and the popup.
+     *
+     * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to format.
+     *
+     * @return string The formatted alert string.
+     */
+    public function formatAlert(MybbStuff_MyAlerts_Entity_Alert $alert, array $outputAlert)
+    {
+        $alertContent = $alert->getExtraDetails();
+
+        return $this->lang->sprintf(
+            $this->lang->myalertsrow_subscribed,
+            $outputAlert['from_user'],
+            $alertContent['thread_title'],
+            $outputAlert['dateline']
+            );
+    }
+
+    /**
+     * Init function called before running formatAlert(). Used to load language files and initialize other required
+     * resources.
+     *
+     * @return void
+     */
+    public function init()
+    {
+        if (!$this->lang->myalerts) {
+            $this->lang->load('myalerts');
+        }
+    }
+
+    /**
+     * Build a link to an alert's content so that the system can redirect to it.
+     *
+     * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the link for.
+     *
+     * @return string The built alert, preferably an absolute link.
+     */
+    public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+    {
+        $alertContent = $alert->getExtraDetails();
+
+        $threadLink = $this->mybb->settings['bburl'] . '/' . get_thread_link(
+            (int) $alertContent['tid'],
+            0,
+            'newpost'
+            );
+
+        return $threadLink;
+    }
+}


### PR DESCRIPTION
From here: http://community.mybb.com/thread-127444-post-1126413.html#pid1126413

Users who are subscribed to a thread will receive a notification when a new reply is made. This excludes the person who made the post. A DB query is made to get the UIDs of all the subscribed users - there is no way to do this type of alert without it. However, other alerts also require queries and I think this alert is important enough to warrant an extra query.
