### PR TITLE
Update myalerts.php

### DIFF
--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -682,7 +682,7 @@ function myalerts_addAlert_pm()
         if (!empty($users)) {
             $Alerts->addMassAlert($users, 'pm', 0, $mybb->user['uid'], array(
                 'pm_title'  =>  $pm['subject'],
-                'pm_id'     =>  $pmhandler->pmid,
+                'pm_id'     =>  implode($pmhandler->pmid),
                 )
             );
         }


### PR DESCRIPTION
Simply using implode on the $pmhandler->pmid will fix the issues with PM alerts.
Would not work with multiple recipients.

Using implode(",", $pmhandler->pmid) returns all pmids correctly in multiusers pm but then all users who the pm is sent to will get the first pmid which is only valid for one of the receivers.
Using explode is one possibility but then again determining the correct pmid for correct users is tricky.