### PR TITLE
Add support for custom pages on mass delete

### DIFF
--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -826,17 +826,16 @@ function myalerts_global_intermediate()
  */
 function myalerts_get_current_url()
 {
-	global $mybb;
+    global $mybb;
 
-	$format = $mybb->settings['bburl'] . '/' . basename($_SERVER['PHP_SELF']);
+    $uri = explode('?', $_SERVER['REQUEST_URI']);
+    $link = $mybb->settings['homeurl'] . htmlspecialchars($uri[0], ENT_QUOTES);
 
-	if (!empty($_GET)) {
-		$format .= '?' . http_build_query($_GET);
-	}
+    if (!empty($_GET)) {
+        $link .= '?' . http_build_query($_GET);
+    }
 
-	$format = rtrim($format, '&');
-
-	return $format;
+    return $link;
 }
 
 $plugins->add_hook(


### PR DESCRIPTION
In v2.0.2, if the user is clicking "Delete All Alerts" or "Delete Read Alerts" on a custom page outside of the board directory, it would set the return links (`ret_link=`) for both as `$mybb->settings['boardurl'] . 'unknown'`.

This fix instead uses both `$mybb->settings['homeurl']` and the request URI to determine where to send the user after performing the appropriate deletion operation.