### PR TITLE
Fix "Unknown Location" in WOL, again

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -8,8 +8,6 @@ define('THIS_SCRIPT', 'alerts.php');
 
 $templatelist = 'myalerts_alert_row_popup,myalerts_alert_row_popup_no_alerts,myalerts_modal_content';
 
-defined('NO_ONLINE') or define('NO_ONLINE', 1);
-
 require_once __DIR__ . '/global.php';
 
 $action = $mybb->get_input('action', MyBB::INPUT_STRING);

--- a/alerts.php
+++ b/alerts.php
@@ -8,9 +8,7 @@ define('THIS_SCRIPT', 'alerts.php');
 
 $templatelist = 'myalerts_alert_row_popup,myalerts_alert_row_popup_no_alerts,myalerts_modal_content';
 
-if ($_GET['action'] == 'modal') {
-	defined('NO_ONLINE') or define('NO_ONLINE', 1);
-}
+defined('NO_ONLINE') or define('NO_ONLINE', 1);
 
 require_once __DIR__ . '/global.php';
 

--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -863,15 +863,13 @@ function myalerts_online_location(&$plugin_array)
 		$lang->load('myalerts');
 	}
 
-	$inUserCpAlerts = $plugin_array['user_activity']['activity'] == 'usercp' AND my_strpos(
-		$plugin_array['user_activity']['location'],
-		'alerts'
-	);
+	if ($plugin_array['user_activity']['activity'] == 'unknown') {
+		$location = $plugin_array['user_activity']['location'];
+		$inAlertsPage = my_strpos($location, "alerts.php");
 
-	$inAlertsPage = $plugin_array['user_activity']['activity'] == 'alerts';
-
-	if ($inUserCpAlerts || $inAlertsPage) {
-		$plugin_array['location_name'] = $lang->myalerts_online_location_listing;
+		if ($inAlertsPage) {
+			$plugin_array['location_name'] = $lang->myalerts_online_location_listing;
+		}
 	}
 }
 


### PR DESCRIPTION
The previous fix (6aaa838c87891a387bc21e1282e2c6ec5cb4afcc) introduces a bug and inconsistencies:

- Missing GET parameter check, this may cause an `undefined index` error. In fact, you can't open the alert page normally without facing the error. 
![image](https://user-images.githubusercontent.com/20620780/75129919-2de6be00-56fe-11ea-9ba3-7dcb114263db.png)

- `modal` is not using the `action` parameter anymore (17643861578e29755029425216bcdd0af74e72d2).

-  Why is it to only define `NO_ONLINE` on `modal`? Opening the alert settings page or any other `action` value still giving "Unknown Location."

Anyway, thanks for this fantastic plugin!