### PR TITLE
Fix #293: The "Who's online" location is broken

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -8,10 +8,6 @@ define('THIS_SCRIPT', 'alerts.php');
 
 $templatelist = 'myalerts_alert_row_popup,myalerts_alert_row_popup_no_alerts,myalerts_modal_content';
 
-if (isset($_GET['action']) && $_GET['action'] == 'modal') {
-	defined('NO_ONLINE') or define('NO_ONLINE', 1);
-}
-
 require_once __DIR__ . '/global.php';
 
 $action = $mybb->get_input('action', MyBB::INPUT_STRING);
@@ -308,8 +304,6 @@ function myalerts_delete_all_alerts($mybb, $db, $lang)
  */
 function myalerts_view_modal($mybb, $lang, $templates, $theme)
 {
-	defined('NO_ONLINE') or define('NO_ONLINE', 1);
-
 	$userAlerts = MybbStuff_MyAlerts_AlertManager::getInstance()
 	                                             ->getAlerts(
 		                                             0,

--- a/inc/plugins/myalerts.php
+++ b/inc/plugins/myalerts.php
@@ -860,25 +860,35 @@ function myalerts_datahandler_user_insert(&$dataHandler)
 }
 
 $plugins->add_hook(
+	'fetch_wol_activity_end',
+	'myalerts_online_activity'
+);
+function myalerts_online_activity($user_activity)
+{
+	if ($user_activity['activity'] == 'unknown') {
+		$split_loc = explode('.php', $user_activity['location']);
+		$filename = my_substr($split_loc[0], -my_strpos(strrev($split_loc[0]), '/'));
+		if ($filename == 'alerts') {
+			$user_activity['activity'] = $filename;
+		}
+	}
+
+	return $user_activity;
+}
+
+$plugins->add_hook(
 	'build_friendly_wol_location_end',
 	'myalerts_online_location'
 );
 function myalerts_online_location(&$plugin_array)
 {
-	global $lang;
+	if ($plugin_array['user_activity']['activity'] == 'alerts') {
+		global $lang;
 
-	if (!isset($lang->myalerts)) {
-		$lang->load('myalerts');
-	}
+		if (!isset($lang->myalerts)) {
+			$lang->load('myalerts');
+		}
 
-	$inUserCpAlerts = $plugin_array['user_activity']['activity'] == 'usercp' AND my_strpos(
-		$plugin_array['user_activity']['location'],
-		'alerts'
-	);
-
-	$inAlertsPage = $plugin_array['user_activity']['activity'] == 'alerts';
-
-	if ($inUserCpAlerts || $inAlertsPage) {
 		$plugin_array['location_name'] = $lang->myalerts_online_location_listing;
 	}
 }


### PR DESCRIPTION
Resolves #293

Supersedes #266 (There's nothing especially wrong with that PR except for its minor failure to remove a mistaken define of NO_ONLINE; I just happened to implement my own fix in the course of all the other fixes I'm submitting tonight).

This PR honours the comment @euantorano made
[here](https://github.com/MyBBStuff/MyAlerts/pull/266#issuecomment-593251171) indicating that a location should be set for the modal. There is, then, never any reason to define NO_ONLINE for any functionality of this plugin.