### PR TITLE
Resolves #240: Typo In Modal Content Template

### DIFF
--- a/inc/plugins/MybbStuff/MyAlerts/templates/modal_content.html
+++ b/inc/plugins/MybbStuff/MyAlerts/templates/modal_content.html
@@ -10,6 +10,7 @@
         <tbody>
         {$alerts}
         </tbody>
+        <tfoot>
         <tr>
             <td class="tfoot smalltext" colspan="3">
                 <a href="{$mybb->settings['bburl']}/alerts.php">{$lang->myalerts_modal_display_alerts}</a>
@@ -24,5 +25,6 @@
                 <!-- Clear alerts link goes here... -->
             </td>
         </tr>
+        </tfoot>
     </table>
 </div>


### PR DESCRIPTION
Apparently, this fix isn't necessary given the second usage note [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#usage_notes), but it improves the HTML and doesn't otherwise hurt.

Fixes #240