### PR TITLE
Fix indentation

### DIFF
--- a/admin/modules/config/myalerts.php
+++ b/admin/modules/config/myalerts.php
@@ -34,7 +34,7 @@ function myalerts_acp_manage_alert_types()
 {
 	global $mybb, $lang, $page;
 
-    myalerts_create_instances();
+	myalerts_create_instances();
 
 	$alertTypeManager = MybbStuff_MyAlerts_AlertTypeManager::getInstance();
 

--- a/alerts.php
+++ b/alerts.php
@@ -67,9 +67,9 @@ switch ($action) {
 		if ($mybb->get_input('modal') == '1') {
 			$unreadOnly = !empty($mybb->cookies['myalerts_unread_only']) && $mybb->cookies['myalerts_unread_only'] != '0';
 			myalerts_view_modal($mybb, $lang, $templates, $theme, $unreadOnly);
-        	} else {
-            		myalerts_view_alerts($mybb, $lang, $templates, $theme);
-        	}
+		} else {
+			myalerts_view_alerts($mybb, $lang, $templates, $theme);
+		}
 		break;
 }
 
@@ -96,8 +96,8 @@ function myalerts_redirect_alert($mybb, $lang)
 	}
 
 	/** @var MybbStuff_MyAlerts_Formatter_AbstractFormatter $alertTypeFormatter */
-	$alertTypeFormatter = MybbStuff_MyAlerts_AlertFormatterManager::getInstance(
-	)->getFormatterForAlertType($alert->getType()->getCode());
+	$alertTypeFormatter = MybbStuff_MyAlerts_AlertFormatterManager::getInstance()
+		->getFormatterForAlertType($alert->getType()->getCode());
 
 	if (!$alert || !$alertTypeFormatter) {
 		error($lang->myalerts_error_alert_not_found);
@@ -136,11 +136,8 @@ function myalerts_alert_settings(
 
 	$alertTypes = $alertTypeManager->getAlertTypes();
 
-	if (strtolower(
-			$mybb->request_method
-		) == 'post'
-	) { // Saving alert type settings
-	    verify_post_check($mybb->get_input('my_post_key'));
+	if (strtolower($mybb->request_method) == 'post') { // Saving alert type settings
+		verify_post_check($mybb->get_input('my_post_key'));
 
 		$disabledAlerts = array();
 
@@ -196,20 +193,15 @@ function myalerts_alert_settings(
 				if (!in_array(
 					$value['id'],
 					$mybb->user['myalerts_disabled_alert_types']
-				)
-				) {
+				)) {
 					$checked = ' checked="checked"';
 				}
 
-				eval("\$alertSettings .= \"" . $templates->get(
-						'myalerts_setting_row'
-					) . "\";");
+				eval("\$alertSettings .= \"" . $templates->get('myalerts_setting_row') . "\";");
 			}
 		}
 
-		eval("\$content = \"" . $templates->get(
-				'myalerts_settings_page'
-			) . "\";");
+		eval("\$content = \"" . $templates->get('myalerts_settings_page') . "\";");
 		output_page($content);
 	}
 }
@@ -289,20 +281,20 @@ function myalerts_delete_read_alerts($mybb, $db, $lang)
 	$retLink = $mybb->get_input('ret_link', MyBB::INPUT_STRING);
 
 	if (!empty($retLink) && stripos($retLink, $mybb->settings['bburl']) === 0) {
-	    $retLink = htmlspecialchars_uni($retLink);
+		$retLink = htmlspecialchars_uni($retLink);
 
-        redirect(
-            $retLink,
-            $lang->myalerts_delete_read,
-            $lang->myalerts_delete_read_deleted
-        );
-    } else {
-        redirect(
-            'alerts.php?action=alerts',
-            $lang->myalerts_delete_read,
-            $lang->myalerts_delete_read_deleted
-        );
-    }
+		redirect(
+			$retLink,
+			$lang->myalerts_delete_read,
+			$lang->myalerts_delete_read_deleted
+		);
+	} else {
+		redirect(
+			'alerts.php?action=alerts',
+			$lang->myalerts_delete_read,
+			$lang->myalerts_delete_read_deleted
+		);
+	}
 }
 
 /**
@@ -320,23 +312,23 @@ function myalerts_delete_all_alerts($mybb, $db, $lang)
 
 	$db->delete_query('alerts', "uid = {$userId}");
 
-    $retLink = $mybb->get_input('ret_link', MyBB::INPUT_STRING);
+	$retLink = $mybb->get_input('ret_link', MyBB::INPUT_STRING);
 
-    if (!empty($retLink) && stripos($retLink, $mybb->settings['bburl']) === 0) {
-        $retLink = htmlspecialchars_uni($retLink);
+	if (!empty($retLink) && stripos($retLink, $mybb->settings['bburl']) === 0) {
+		$retLink = htmlspecialchars_uni($retLink);
 
-        redirect(
-            $retLink,
-            $lang->myalerts_delete_all,
-            $lang->myalerts_delete_mass_deleted
-        );
-    } else {
-        redirect(
-            'alerts.php?action=alerts',
-            $lang->myalerts_delete_all,
-            $lang->myalerts_delete_mass_deleted
-        );
-    }
+		redirect(
+			$retLink,
+			$lang->myalerts_delete_all,
+			$lang->myalerts_delete_mass_deleted
+		);
+	} else {
+		redirect(
+			'alerts.php?action=alerts',
+			$lang->myalerts_delete_all,
+			$lang->myalerts_delete_mass_deleted
+		);
+	}
 }
 
 /**
@@ -351,11 +343,11 @@ function myalerts_delete_all_alerts($mybb, $db, $lang)
 function myalerts_view_modal($mybb, $lang, $templates, $theme, $unreadOnly = false)
 {
 	$userAlerts = MybbStuff_MyAlerts_AlertManager::getInstance()
-	                                             ->getAlerts(
-		                                             0,
-		                                             $mybb->settings['myalerts_dropdown_limit'],
-		                                             $unreadOnly
-	                                             );
+		->getAlerts(
+			0,
+			$mybb->settings['myalerts_dropdown_limit'],
+			$unreadOnly
+		);
 
 	$alerts = '';
 
@@ -416,7 +408,7 @@ function myalerts_view_modal($mybb, $lang, $templates, $theme, $unreadOnly = fal
  */
 function myalerts_view_alerts($mybb, $lang, $templates, $theme)
 {
-    myalerts_create_instances();
+	myalerts_create_instances();
 
 	$alerts = MybbStuff_MyAlerts_AlertManager::getInstance()->getAlerts(0, 10);
 

--- a/inc/plugins/MybbStuff/MyAlerts/src/AlertFormatterManager.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/AlertFormatterManager.php
@@ -105,9 +105,9 @@ class MybbStuff_MyAlerts_AlertFormatterManager
 			/** @var MybbStuff_MyAlerts_Formatter_AbstractFormatter $formatter */
 			$formatter = new $formatterClass($this->mybb, $this->lang);
 			$formatter->init();
-		} elseif (is_object(
-				$formatterClass
-			) && $formatterClass instanceof MybbStuff_MyAlerts_Formatter_AbstractFormatter
+		} elseif (is_object($formatterClass)
+		          &&
+		          $formatterClass instanceof MybbStuff_MyAlerts_Formatter_AbstractFormatter
 		) {
 			$formatter = $formatterClass;
 		} else {

--- a/inc/plugins/MybbStuff/MyAlerts/src/AlertManager.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/AlertManager.php
@@ -271,10 +271,7 @@ class MybbStuff_MyAlerts_AlertManager
 			$alert->getType(),
 			array($alert->getUserId())
 		);
-		if ($alertType->getEnabled(
-			) && (!empty($usersWhoWantAlert) || !$alertType->getCanBeUserDisabled(
-				))
-		) {
+		if ($alertType->getEnabled() && (!empty($usersWhoWantAlert) || !$alertType->getCanBeUserDisabled())) {
 			if ($alertType->getCode() === 'quoted') {
 				// If there is already an alert queued to the user of the type
 				// 'post_threadauthor', don't add the alert.
@@ -298,9 +295,7 @@ class MybbStuff_MyAlerts_AlertManager
 			);
 
 			// Basic duplicate checking by overwrite - only one alert for each alert type/object id combination
-			static::$alertQueue[$alert->getType()->getCode(
-			) . '_' . $alert->getUserId() . '_' . $alert->getObjectId(
-			)] = $alert;
+			static::$alertQueue[$alert->getType()->getCode() . '_' . $alert->getUserId() . '_' . $alert->getObjectId()] = $alert;
 		}
 
 		return $this;
@@ -423,9 +418,9 @@ class MybbStuff_MyAlerts_AlertManager
 				$prefix = TABLE_PREFIX;
 
 				$queryString = <<<SQL
-                SELECT COUNT(*) AS count FROM {$prefix}alerts a
-                INNER JOIN {$prefix}alert_types t ON (a.alert_type_id = t.id)
-                WHERE (a.alert_type_id IN ({$alertTypes}) OR a.forced = 1 OR t.can_be_user_disabled = 0) AND t.enabled = 1 AND a.uid = {$this->mybb->user['uid']};
+SELECT COUNT(*) AS count FROM {$prefix}alerts a
+INNER JOIN {$prefix}alert_types t ON (a.alert_type_id = t.id)
+WHERE (a.alert_type_id IN ({$alertTypes}) OR a.forced = 1 OR t.can_be_user_disabled = 0) AND t.enabled = 1 AND a.uid = {$this->mybb->user['uid']};
 SQL;
 
 				$query = $this->db->write_query($queryString);
@@ -469,9 +464,9 @@ SQL;
 
 				$prefix = TABLE_PREFIX;
 				$queryString = <<<SQL
-                SELECT COUNT(*) AS count FROM {$prefix}alerts a
-                INNER JOIN {$prefix}alert_types t ON (a.alert_type_id = t.id)
-                WHERE (a.alert_type_id IN ({$alertTypes}) OR a.forced = 1 OR t.can_be_user_disabled = 0) AND t.enabled = 1 AND a.uid = {$this->mybb->user['uid']} AND a.unread = 1;
+SELECT COUNT(*) AS count FROM {$prefix}alerts a
+INNER JOIN {$prefix}alert_types t ON (a.alert_type_id = t.id)
+WHERE (a.alert_type_id IN ({$alertTypes}) OR a.forced = 1 OR t.can_be_user_disabled = 0) AND t.enabled = 1 AND a.uid = {$this->mybb->user['uid']} AND a.unread = 1;
 SQL;
 
 				$query = $this->db->write_query($queryString);;

--- a/inc/plugins/MybbStuff/MyAlerts/src/AlertTypeManager.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/AlertTypeManager.php
@@ -5,281 +5,281 @@
  */
 class MybbStuff_MyAlerts_AlertTypeManager
 {
-    const CACHE_NAME = 'mybbstuff_myalerts_alert_types';
+	const CACHE_NAME = 'mybbstuff_myalerts_alert_types';
 
-    /** @var MybbStuff_MyAlerts_AlertTypeManager */
-    private static $instance = null;
+	/** @var MybbStuff_MyAlerts_AlertTypeManager */
+	private static $instance = null;
 
-    /** @var array */
-    private $alertTypes = array();
+	/** @var array */
+	private $alertTypes = array();
 
-    /** @var DB_Base */
-    private $db;
+	/** @var DB_Base */
+	private $db;
 
-    /** @var datacache */
-    private $cache;
+	/** @var datacache */
+	private $cache;
 
-    private function __construct(DB_Base $db, datacache $cache)
-    {
-        $this->db = $db;
-        $this->cache = $cache;
+	private function __construct(DB_Base $db, datacache $cache)
+	{
+		$this->db = $db;
+		$this->cache = $cache;
 
-        $this->getAlertTypes();
-    }
+		$this->getAlertTypes();
+	}
 
-    /**
-     * Get all of the alert types in the system.
-     *
-     * Alert types are both stored in the private $alertTypes variable and are
-     * also returned for usage.
-     *
-     * @param bool $forceDatabase Whether to force the reading of alert types
-     *                            from the database.
-     *
-     * @return array All of the alert types currently in the system.
-     */
-    public function getAlertTypes($forceDatabase = false)
-    {
-        $forceDatabase = (bool) $forceDatabase;
+	/**
+	 * Get all of the alert types in the system.
+	 *
+	 * Alert types are both stored in the private $alertTypes variable and are
+	 * also returned for usage.
+	 *
+	 * @param bool $forceDatabase Whether to force the reading of alert types
+	 *                            from the database.
+	 *
+	 * @return array All of the alert types currently in the system.
+	 */
+	public function getAlertTypes($forceDatabase = false)
+	{
+		$forceDatabase = (bool) $forceDatabase;
 
-        $this->alertTypes = array();
+		$this->alertTypes = array();
 
-        if (($cachedAlertTypes = $this->cache->read(self::CACHE_NAME)) === false || $forceDatabase) {
-            $this->alertTypes = $this->loadAlertTypes();
-            $this->cache->update(self::CACHE_NAME, $this->alertTypes);
-        } else {
-            $this->alertTypes = $cachedAlertTypes;
-        }
+		if (($cachedAlertTypes = $this->cache->read(self::CACHE_NAME)) === false || $forceDatabase) {
+			$this->alertTypes = $this->loadAlertTypes();
+			$this->cache->update(self::CACHE_NAME, $this->alertTypes);
+		} else {
+			$this->alertTypes = $cachedAlertTypes;
+		}
 
-        return $this->alertTypes;
-    }
+		return $this->alertTypes;
+	}
 
-    /**
-     * Load all of the alert types currently in the system from the database.
-     * Should only be used to refresh the cache.
-     *
-     * @return MybbStuff_MyAlerts_Entity_AlertType[] All of the alert types
-     *                                               currently in the database.
-     */
-    private function loadAlertTypes()
-    {
-        $query = $this->db->simple_select('alert_types', '*');
+	/**
+	 * Load all of the alert types currently in the system from the database.
+	 * Should only be used to refresh the cache.
+	 *
+	 * @return MybbStuff_MyAlerts_Entity_AlertType[] All of the alert types
+	 *                                               currently in the database.
+	 */
+	private function loadAlertTypes()
+	{
+		$query = $this->db->simple_select('alert_types', '*');
 
-        $alertTypes = array();
+		$alertTypes = array();
 
-        while ($row = $this->db->fetch_array($query)) {
-            $alertType = new MybbStuff_MyAlerts_Entity_AlertType();
-            $alertType->setId($row['id']);
-            $alertType->setCode($row['code']);
-            $alertType->setEnabled((int) $row['enabled'] == 1);
-            $alertType->setCanBeUserDisabled(
-                (int) $row['can_be_user_disabled'] == 1
-            );
-            $alertType->setDefaultUserEnabled(
-                (int) $row['default_user_enabled'] == 1
-            );
+		while ($row = $this->db->fetch_array($query)) {
+			$alertType = new MybbStuff_MyAlerts_Entity_AlertType();
+			$alertType->setId($row['id']);
+			$alertType->setCode($row['code']);
+			$alertType->setEnabled((int) $row['enabled'] == 1);
+			$alertType->setCanBeUserDisabled(
+				(int) $row['can_be_user_disabled'] == 1
+			);
+			$alertType->setDefaultUserEnabled(
+				(int) $row['default_user_enabled'] == 1
+			);
 
-            $alertTypes[$row['code']] = $alertType->toArray();
-        }
+			$alertTypes[$row['code']] = $alertType->toArray();
+		}
 
-        return $alertTypes;
-    }
+		return $alertTypes;
+	}
 
-    /**
-     * Create an instance of the alert type manager.
-     *
-     * @param DB_Base   $db    MyBB database object.
-     * @param datacache $cache MyBB cache object.
-     *
-     * @return MybbStuff_MyAlerts_AlertTypeManager The created instance.
-     */
-    public static function createInstance(DB_Base $db, datacache $cache)
-    {
-        if (static::$instance === null) {
-            static::$instance = new self($db, $cache);
-        }
+	/**
+	 * Create an instance of the alert type manager.
+	 *
+	 * @param DB_Base   $db    MyBB database object.
+	 * @param datacache $cache MyBB cache object.
+	 *
+	 * @return MybbStuff_MyAlerts_AlertTypeManager The created instance.
+	 */
+	public static function createInstance(DB_Base $db, datacache $cache)
+	{
+		if (static::$instance === null) {
+			static::$instance = new self($db, $cache);
+		}
 
-        return static::$instance;
-    }
+		return static::$instance;
+	}
 
-    /**
-     * Get a prior created instance of the alert type manager. @see createInstance().
-     *
-     * @return bool|MybbStuff_MyAlerts_AlertTypeManager The prior created
-     *                                                  instance, or false if
-     *                                                  not already
-     *                                                  instantiated.
-     */
-    public static function getInstance()
-    {
-        if (static::$instance === null) {
-            return false;
-        }
+	/**
+	 * Get a prior created instance of the alert type manager. @see createInstance().
+	 *
+	 * @return bool|MybbStuff_MyAlerts_AlertTypeManager The prior created
+	 *                                                  instance, or false if
+	 *                                                  not already
+	 *                                                  instantiated.
+	 */
+	public static function getInstance()
+	{
+		if (static::$instance === null) {
+		return false;
+		}
 
-        return static::$instance;
-    }
+		return static::$instance;
+	}
 
-    /**
-     * @param MybbStuff_MyAlerts_Entity_AlertType $alertType
-     *
-     * @return bool Whether the alert type was added successfully.
-     */
-    public function add(MybbStuff_MyAlerts_Entity_AlertType $alertType)
-    {
-        $success = true;
+	/**
+	 * @param MybbStuff_MyAlerts_Entity_AlertType $alertType
+	 *
+	 * @return bool Whether the alert type was added successfully.
+	 */
+	public function add(MybbStuff_MyAlerts_Entity_AlertType $alertType)
+	{
+		$success = true;
 
-        if (!isset($this->alertTypes[$alertType->getCode()])) {
-            $insertArray = $alertType->toArray();
+		if (!isset($this->alertTypes[$alertType->getCode()])) {
+			$insertArray = $alertType->toArray();
 
-            if (isset($insertArray['id'])) {
-                unset($insertArray['id']);
-            }
+			if (isset($insertArray['id'])) {
+				unset($insertArray['id']);
+			}
 
-            $success = (bool) $this->db->insert_query(
-                'alert_types',
-                $insertArray
-            );
+			$success = (bool) $this->db->insert_query(
+				'alert_types',
+				$insertArray
+			);
 
-            $this->getAlertTypes(true);
-        }
+			$this->getAlertTypes(true);
+		}
 
-        return $success;
-    }
+		return $success;
+	}
 
-    /**
-     * Add multiple alert types.
-     *
-     * @param MybbStuff_MyAlerts_Entity_AlertType[] $alertTypes AN array of
-     *                                                          alert types to
-     *                                                          add.
-     *
-     * @return bool Whether the alert types were added successfully.
-     */
-    public function addTypes(array $alertTypes)
-    {
-        $toInsert = array();
-        $success = true;
+	/**
+	 * Add multiple alert types.
+	 *
+	 * @param MybbStuff_MyAlerts_Entity_AlertType[] $alertTypes AN array of
+	 *                                                          alert types to
+	 *                                                          add.
+	 *
+	 * @return bool Whether the alert types were added successfully.
+	 */
+	public function addTypes(array $alertTypes)
+	{
+		$toInsert = array();
+		$success = true;
 
-        foreach ($alertTypes as $alertType) {
-            if ($alertType instanceof MybbStuff_MyAlerts_Entity_AlertType) {
-                if (!isset($this->alertTypes[$alertType->getCode()])) {
-                    $insertArray = $alertType->toArray();
+		foreach ($alertTypes as $alertType) {
+			if ($alertType instanceof MybbStuff_MyAlerts_Entity_AlertType) {
+				if (!isset($this->alertTypes[$alertType->getCode()])) {
+					$insertArray = $alertType->toArray();
 
-                    if (isset($insertArray['id'])) {
-                        unset($insertArray['id']);
-                    }
+					if (isset($insertArray['id'])) {
+						unset($insertArray['id']);
+					}
 
-                    $toInsert[] = $insertArray;
-                }
-            }
-        }
+					$toInsert[] = $insertArray;
+				}
+			}
+		}
 
-        if (!empty($toInsert)) {
-            $success = (bool) $this->db->insert_query_multiple(
-                'alert_types',
-                $toInsert
-            );
-        }
+		if (!empty($toInsert)) {
+			$success = (bool) $this->db->insert_query_multiple(
+				'alert_types',
+				$toInsert
+			);
+		}
 
-        $this->getAlertTypes(true);
+		$this->getAlertTypes(true);
 
-        return $success;
-    }
+		return $success;
+	}
 
-    /**
-     * Update a set of alert types to change their enabled/disabled status.
-     *
-     * @param MybbStuff_MyAlerts_Entity_AlertType[] $alertTypes An array of
-     *                                                          alert types to
-     *                                                          update.
-     */
-    public function updateAlertTypes(array $alertTypes)
-    {
-        foreach ($alertTypes as $alertType) {
-            if (!($alertType instanceof MybbStuff_MyAlerts_Entity_AlertType)) {
-                continue;
-            }
+	/**
+	 * Update a set of alert types to change their enabled/disabled status.
+	 *
+	 * @param MybbStuff_MyAlerts_Entity_AlertType[] $alertTypes An array of
+	 *                                                          alert types to
+	 *                                                          update.
+	 */
+	public function updateAlertTypes(array $alertTypes)
+	{
+		foreach ($alertTypes as $alertType) {
+			if (!($alertType instanceof MybbStuff_MyAlerts_Entity_AlertType)) {
+				continue;
+			}
 
-            $updateArray = array(
-                'enabled'              => (int) $alertType->getEnabled(),
-                'can_be_user_disabled' => (int) $alertType->getCanBeUserDisabled(),
-                'default_user_enabled' => (int) $alertType->getDefaultUserEnabled(),
-            );
+			$updateArray = array(
+				'enabled'              => (int) $alertType->getEnabled(),
+				'can_be_user_disabled' => (int) $alertType->getCanBeUserDisabled(),
+				'default_user_enabled' => (int) $alertType->getDefaultUserEnabled(),
+			);
 
-            $id = (int) $alertType->getId();
+			$id = (int) $alertType->getId();
 
-            $this->db->update_query(
-                'alert_types',
-                $updateArray,
-                "id = {$id}"
-            );
-        }
+			$this->db->update_query(
+				'alert_types',
+				$updateArray,
+				"id = {$id}"
+			);
+		}
 
-        // Flush the cache
-        $this->getAlertTypes(true);
-    }
+		// Flush the cache
+		$this->getAlertTypes(true);
+	}
 
-    /**
-     * Delete an alert type by the unique code assigned to it.
-     *
-     * @param string $code The unique code for the alert type.
-     *
-     * @return bool Whether the alert type was deleted.
-     */
-    public function deleteByCode($code = '')
-    {
-        $alertType = $this->getByCode($code);
+	/**
+	 * Delete an alert type by the unique code assigned to it.
+	 *
+	 * @param string $code The unique code for the alert type.
+	 *
+	 * @return bool Whether the alert type was deleted.
+	 */
+	public function deleteByCode($code = '')
+	{
+		$alertType = $this->getByCode($code);
 
-        if ($alertType !== null) {
-            return $this->deleteById($alertType->getId());
-        }
+		if ($alertType !== null) {
+		return $this->deleteById($alertType->getId());
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get an alert type by it's code.
-     *
-     * @param string $code The code of the alert type to fetch.
-     *
-     * @return MybbStuff_MyAlerts_Entity_AlertType|null The found alert type or
-     *                                                  null if it doesn't
-     *                                                  exist (hasn't yet been
-     *                                                  registered).
-     */
-    public function getByCode($code = '')
-    {
-        $code = (string) $code;
+	/**
+	 * Get an alert type by it's code.
+	 *
+	 * @param string $code The code of the alert type to fetch.
+	 *
+	 * @return MybbStuff_MyAlerts_Entity_AlertType|null The found alert type or
+	 *                                                  null if it doesn't
+	 *                                                  exist (hasn't yet been
+	 *                                                  registered).
+	 */
+	public function getByCode($code = '')
+	{
+		$code = (string) $code;
 
-        $alertType = null;
+		$alertType = null;
 
-        if (isset($this->alertTypes[$code])) {
-            $alertType = MybbStuff_MyAlerts_Entity_AlertType::unserialize(
-                $this->alertTypes[$code]
-            );
-        }
+		if (isset($this->alertTypes[$code])) {
+			$alertType = MybbStuff_MyAlerts_Entity_AlertType::unserialize(
+				$this->alertTypes[$code]
+			);
+		}
 
-        return $alertType;
-    }
+		return $alertType;
+	}
 
-    /**
-     * Delete an alert type by ID.
-     *
-     * @param int $id The ID of the alert type.
-     *
-     * @return bool Whether the alert type was deleted.
-     */
-    public function deleteById($id = 0)
-    {
-        $id = (int) $id;
+	/**
+	 * Delete an alert type by ID.
+	 *
+	 * @param int $id The ID of the alert type.
+	 *
+	 * @return bool Whether the alert type was deleted.
+	 */
+	public function deleteById($id = 0)
+	{
+		$id = (int) $id;
 
-        $queryResult = (bool) $this->db->delete_query(
-            'alert_types',
-            "id = {$id}"
-        );
+		$queryResult = (bool) $this->db->delete_query(
+			'alert_types',
+			"id = {$id}"
+		);
 
-        $this->getAlertTypes(true);
+		$this->getAlertTypes(true);
 
-        return $queryResult;
-    }
+		return $queryResult;
+	}
 }

--- a/inc/plugins/MybbStuff/MyAlerts/stylesheets/alerts.css
+++ b/inc/plugins/MybbStuff/MyAlerts/stylesheets/alerts.css
@@ -1,33 +1,33 @@
 .usercp_nav_myalerts {
-    background: url(images/usercp/transmit_blue.png) no-repeat left center !important;
+	background: url(images/usercp/transmit_blue.png) no-repeat left center !important;
 }
 
 .usercp_nav_myalerts_delete_all {
-    background: url(images/usercp/delete.png) no-repeat left center !important;
+	background: url(images/usercp/delete.png) no-repeat left center !important;
 }
 
 .usercp_nav_myalerts_delete_read {
-    background: url(images/usercp/bin.png) no-repeat left center !important;
+	background: url(images/usercp/bin.png) no-repeat left center !important;
 }
 
 .newAlerts > a {
-    color: red !important;
+	color: red !important;
 }
 
 ul.panel_links a.myalerts {
-    background-position: 0 -180px;
+	background-position: 0 -180px;
 }
 
 .alert-row__no-alerts td {
-    text-align: center;
+	text-align: center;
 }
 
 .alert--read.alert {
-    opacity: .5;
+	opacity: .5;
 }
 
 .alert.alert--read td.trow1 {
-    background-color: #F5F5F5;
+	background-color: #F5F5F5;
 }
 
 .alerts--new a {

--- a/inc/plugins/MybbStuff/MyAlerts/templates/usercp_nav.html
+++ b/inc/plugins/MybbStuff/MyAlerts/templates/usercp_nav.html
@@ -6,9 +6,9 @@
                  class="expander" alt="{$expaltext}" title="{$expaltext}" />
         </div>
         <div>
-			<span class="smalltext">
-				<strong>{$lang->myalerts_usercp_nav}</strong>
-			</span>
+            <span class="smalltext">
+                <strong>{$lang->myalerts_usercp_nav}</strong>
+            </span>
         </div>
     </td>
 </tr>

--- a/jscripts/myalerts.js
+++ b/jscripts/myalerts.js
@@ -69,8 +69,8 @@
                     if (data.error) {
                         $.jGrowl(data.error, {theme:'jgrowl_error'});
                     } else {
-	                    $('#myalerts_alerts_modal tbody:first').html(data['template']);
-    	                MybbStuff.MyAlerts.prototype.updateVisibleCounts(0, 0);
+                        $('#myalerts_alerts_modal tbody:first').html(data['template']);
+                        MybbStuff.MyAlerts.prototype.updateVisibleCounts(0, 0);
                     }
                 });
             }


### PR DESCRIPTION
Sometimes spaces were used instead of tabs in .php files. Conversely, sometimes tabs were used instead of spaces in .js files or templates.

Also fix a few convoluted spacings of expressions.