### PR TITLE
Implement return types and type hints

### DIFF
--- a/admin/modules/config/myalerts.php
+++ b/admin/modules/config/myalerts.php
@@ -10,6 +10,8 @@
  * @version 2.0.0
  */
 
+declare(strict_types=1);
+
 if (!defined('IN_MYBB')) {
 	die('Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.');
 }
@@ -30,7 +32,7 @@ switch ($mybb->get_input('action')) {
 		break;
 }
 
-function myalerts_acp_manage_alert_types()
+function myalerts_acp_manage_alert_types(): void
 {
 	global $mybb, $lang, $page;
 
@@ -99,7 +101,7 @@ function myalerts_acp_manage_alert_types()
 			'index.php?module=config-myalerts_alert_types', 'post'
 		);
 
-		$table = new Table;
+		$table = new Table();
 		$table->construct_header($lang->myalerts_alert_type_code);
 		$table->construct_header(
 			$lang->myalerts_alert_type_enabled,

--- a/alerts.php
+++ b/alerts.php
@@ -10,7 +10,7 @@ $templatelist = 'myalerts_alert_row_popup,myalerts_alert_row_popup_no_alerts,mya
 
 require_once __DIR__ . '/global.php';
 
-$action = $mybb->get_input('action', MyBB::INPUT_STRING);
+$action = $mybb->get_input('action');
 
 if (!isset($lang->myalerts)) {
 	$lang->load('myalerts');
@@ -249,7 +249,7 @@ function myalerts_mark_all_alerts_read($mybb, $lang)
 
 	MybbStuff_MyAlerts_AlertManager::getInstance()->markAllRead();
 
-	$retLink = $mybb->get_input('ret_link', MyBB::INPUT_STRING);
+	$retLink = $mybb->get_input('ret_link');
 
 	if (!empty($retLink) && stripos($retLink, $mybb->settings['bburl']) === 0) {
 		$retLink = htmlspecialchars_uni($retLink);
@@ -278,7 +278,7 @@ function myalerts_delete_read_alerts($mybb, $db, $lang)
 
 	$db->delete_query('alerts', "uid = {$userId} AND unread = 0");
 
-	$retLink = $mybb->get_input('ret_link', MyBB::INPUT_STRING);
+	$retLink = $mybb->get_input('ret_link');
 
 	if (!empty($retLink) && stripos($retLink, $mybb->settings['bburl']) === 0) {
 		$retLink = htmlspecialchars_uni($retLink);
@@ -312,7 +312,7 @@ function myalerts_delete_all_alerts($mybb, $db, $lang)
 
 	$db->delete_query('alerts', "uid = {$userId}");
 
-	$retLink = $mybb->get_input('ret_link', MyBB::INPUT_STRING);
+	$retLink = $mybb->get_input('ret_link');
 
 	if (!empty($retLink) && stripos($retLink, $mybb->settings['bburl']) === 0) {
 		$retLink = htmlspecialchars_uni($retLink);
@@ -338,7 +338,7 @@ function myalerts_delete_all_alerts($mybb, $db, $lang)
  * @param MyLanguage $lang       Language object.
  * @param templates  $templates  Template manager.
  * @param array      $theme      Details about the current theme.
- * @param boolean    $unreadOnly Whether to show only unread alerts.
+ * @param bool    $unreadOnly Whether to show only unread alerts.
  */
 function myalerts_view_modal($mybb, $lang, $templates, $theme, $unreadOnly = false)
 {
@@ -379,7 +379,7 @@ function myalerts_view_modal($mybb, $lang, $templates, $theme, $unreadOnly = fal
 		));
 	}
 
-	$myalerts_return_link = $mybb->get_input('ret_link', MyBB::INPUT_STRING);
+	$myalerts_return_link = $mybb->get_input('ret_link');
 
 	if (!empty($myalerts_return_link)) {
 		if (stripos($myalerts_return_link, $mybb->settings['bburl']) !== 0) {

--- a/inc/plugins/MybbStuff/MyAlerts/src/AlertManager.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/AlertManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Manages the creating, fetching and manipulating of alerts within the
  * database.
@@ -9,39 +11,39 @@
 class MybbStuff_MyAlerts_AlertManager
 {
 	/** @var string The version of the AlertManager. */
-	const VERSION                = '2.1.0-beta';
-	const FIND_USERS_BY_UID      = 0;
-	const FIND_USERS_BY_USERNAME = 1;
+	public const VERSION = '2.1.0-beta';
+	public const FIND_USERS_BY_UID = 0;
+	public const FIND_USERS_BY_USERNAME = 1;
 	/**
 	 * @var MybbStuff_MyAlerts_Entity_Alert[] A queue of alerts waiting to be
 	 *      committed to the database.
 	 */
-	private static $alertQueue;
+	private static array $alertQueue;
 	/** @var  MybbStuff_MyAlerts_Entity_AlertType[] A cache of the alert types currently available in the system. */
-	private static $alertTypes;
+	private static array $alertTypes;
 	/** @var MybbStuff_MyAlerts_AlertManager */
-	private static $instance = null;
+	private static MybbStuff_MyAlerts_AlertManager $instance;
 	/** @var MyBB MyBB core object used to get settings and more. */
-	private $mybb;
+	private MyBB $mybb;
 	/** @var DB_Base Database connection to be used when manipulating alerts. */
-	private $db;
+	private DB_Base $db;
 	/** @var datacache Cache instance used to manipulate alerts. */
-	private $cache;
+	private datacache $cache;
 	/** @var pluginSystem $plugins MyBB plugin system. */
-	private $plugins;
+	private pluginSystem $plugins;
 	/** @var MybbStuff_MyAlerts_AlertTypeManager $alertTypeManager */
-	private $alertTypeManager;
+	private \MybbStuff_MyAlerts_AlertTypeManager $alertTypeManager;
 	/** @var array An array of the currently enabled alert types for the user. */
-	private $currentUserEnabledAlerts = array();
+	private array $currentUserEnabledAlerts = array();
 	/**
 	 * Whether the commit() function is registered.
 	 */
-	public static $isCommitRegistered = false;
+	public static bool $isCommitRegistered = false;
 
 	/**
-	 * Initialise a new instance of the AlertManager.
+	 * Initialize a new instance of the AlertManager.
 	 *
-	 * @param MyBB                                $mybb             MyBB core
+	 * @param MyBB $mybb             MyBB core
 	 *                                                              object used
 	 *                                                              to get
 	 *                                                              settings
@@ -66,10 +68,10 @@ class MybbStuff_MyAlerts_AlertManager
 	 *                                                              instance.
 	 */
 	private function __construct(
-		$mybb,
-		DB_Base $db,
-		datacache $cache,
-		pluginSystem $plugins,
+		MyBB                                $mybb,
+		DB_Base                             $db,
+		datacache                           $cache,
+		pluginSystem                        $plugins,
 		MybbStuff_MyAlerts_AlertTypeManager $alertTypeManager
 	) {
 		$this->mybb = $mybb;
@@ -94,9 +96,8 @@ class MybbStuff_MyAlerts_AlertManager
 	 *
 	 * @return array The filtered array.
 	 */
-	private function filterEnabledAlerts($userDisabledAlertIds = array())
+	private function filterEnabledAlerts(array $userDisabledAlertIds = array()): array
 	{
-		$userDisabledAlertIds = (array) $userDisabledAlertIds;
 		$alertTypes = $this->alertTypeManager->getAlertTypes();
 		$enabledAlertTypes = array();
 
@@ -112,7 +113,7 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * @return MybbStuff_MyAlerts_Entity_Alert[]
 	 */
-	public static function getAlertQueue()
+	public static function getAlertQueue(): array
 	{
 		return self::$alertQueue;
 	}
@@ -120,7 +121,7 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * @return MybbStuff_MyAlerts_Entity_AlertType[]
 	 */
-	public static function getAlertTypes()
+	public static function getAlertTypes(): array
 	{
 		return self::$alertTypes;
 	}
@@ -148,7 +149,7 @@ class MybbStuff_MyAlerts_AlertManager
 		datacache $cache,
 		pluginSystem $plugins,
 		MybbStuff_MyAlerts_AlertTypeManager $alertTypeManager
-	) {
+	): self {
 		if (static::$instance === null) {
 			static::$instance = new self(
 				$mybb,
@@ -163,17 +164,16 @@ class MybbStuff_MyAlerts_AlertManager
 	}
 
 	/**
-	 * Get a prior created instance of the alert manager. @see
-	 * createInstance().
+	 * Get a prior-created instance of the alert manager.
+	 * @return MybbStuff_MyAlerts_AlertManager The existing instance, or false if not already instantiated.
+	 * @throws Exception
+	 * @see createInstance().
 	 *
-	 * @return bool|MybbStuff_MyAlerts_AlertManager The existing instance, or
-	 *                                              false if not already
-	 *                                              instantiated.
 	 */
-	public static function getInstance()
+	public static function getInstance(): self
 	{
-		if (static::$instance === null) {
-			return false;
+		if (!(static::$instance instanceof MybbStuff_MyAlerts_AlertManager)) {
+			throw new Exception('Alert manager not instantiated. Call createInstance() first.');
 		}
 
 		return static::$instance;
@@ -182,7 +182,7 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * @return MyBB
 	 */
-	public function getMybb()
+	public function getMybb(): MyBB
 	{
 		return $this->mybb;
 	}
@@ -190,7 +190,7 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * @return DB_Base
 	 */
-	public function getDb()
+	public function getDb(): DB_Base
 	{
 		return $this->db;
 	}
@@ -198,7 +198,7 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * @return datacache
 	 */
-	public function getCache()
+	public function getCache(): datacache
 	{
 		return $this->cache;
 	}
@@ -206,7 +206,7 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * @return pluginSystem
 	 */
-	public function getPlugins()
+	public function getPlugins(): pluginSystem
 	{
 		return $this->plugins;
 	}
@@ -214,7 +214,7 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * @return MybbStuff_MyAlerts_AlertTypeManager
 	 */
-	public function getAlertTypeManager()
+	public function getAlertTypeManager(): MybbSTuff_MyAlerts_AlertTypeManager
 	{
 		return $this->alertTypeManager;
 	}
@@ -222,7 +222,7 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * @return array
 	 */
-	public function getCurrentUserEnabledAlerts()
+	public function getCurrentUserEnabledAlerts(): array
 	{
 		return $this->currentUserEnabledAlerts;
 	}
@@ -232,7 +232,7 @@ class MybbStuff_MyAlerts_AlertManager
 	 *
 	 * @return array An array of settings and values.
 	 */
-	public function settings()
+	public function settings(): array
 	{
 		return $this->mybb->settings;
 	}
@@ -240,10 +240,9 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * Add a list of alerts.
 	 *
-	 * @param MybbStuff_MyAlerts_Entity_Alert[] $alerts An array of alerts to
-	 *                                                  add.
+	 * @param MybbStuff_MyAlerts_Entity_Alert[] $alerts An array of alerts to add.
 	 */
-	public function addAlerts(array $alerts)
+	public function addAlerts(array $alerts): void
 	{
 		foreach ($alerts as $alert) {
 			$this->addAlert($alert);
@@ -257,7 +256,7 @@ class MybbStuff_MyAlerts_AlertManager
 	 *
 	 * @return $this
 	 */
-	public function addAlert(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function addAlert(MybbStuff_MyAlerts_Entity_Alert $alert): MybbStuff_MyAlerts_AlertManager
 	{
 		$fromUser = $alert->getFromUser();
 
@@ -294,7 +293,7 @@ class MybbStuff_MyAlerts_AlertManager
 				$passToHook
 			);
 
-			// Basic duplicate checking by overwrite - only one alert for each alert type/object id combination
+			// Basic duplicate checking by overwriting - only one alert for each alert type/object id combination
 			static::$alertQueue[$alert->getType()->getCode() . '_' . $alert->getUserId() . '_' . $alert->getObjectId()] = $alert;
 		}
 
@@ -304,24 +303,18 @@ class MybbStuff_MyAlerts_AlertManager
 	/**
 	 * Get the users who want to receive a certain alert type.
 	 *
-	 * @param MybbStuff_MyAlerts_Entity_AlertType $alertType   The alert type
-	 *                                                         to check.
-	 * @param array                               $users       An array of User
-	 *                                                         IDs to check.
-	 * @param int                                 $findUsersBy The column to
-	 *                                                         find users by.
-	 *                                                         Should be one of
-	 *                                                         FIND_USERS_BY_UID
-	 *                                                         or
-	 *                                                         FIND_USERS_BY_USERNAME
+	 * @param MybbStuff_MyAlerts_Entity_AlertType $alertType   The alert type to check.
+	 * @param array $users An array of User IDs to check.
+	 * @param int $findUsersBy The column to find users by. Should be one of FIND_USERS_BY_UID or FIND_USERS_BY_USERNAME
 	 *
 	 * @return array
 	 */
 	public function doUsersWantAlert(
 		MybbStuff_MyAlerts_Entity_AlertType $alertType,
 		array $users = array(),
-		$findUsersBy = self::FIND_USERS_BY_UID
-	) {
+		int $findUsersBy = self::FIND_USERS_BY_UID
+	): array
+	{
 		$usersWhoWantAlert = array();
 
 		switch ($findUsersBy) {
@@ -370,8 +363,10 @@ class MybbStuff_MyAlerts_AlertManager
 	 *
 	 * @return bool Whether the alerts were added successfully.
 	 */
-	public function commit()
+	public function commit(): bool
 	{
+		$success = false;
+
 		if (empty(static::$alertQueue)) {
 			$success = true;
 		} else {
@@ -390,10 +385,15 @@ class MybbStuff_MyAlerts_AlertManager
 			// Empty the alert queue.
 			static::$alertQueue = array();
 
-			$success = (boolean) $this->db->insert_query_multiple(
-				'alerts',
-				$toCommit
-			);
+			try {
+				$this->db->insert_query_multiple(
+					'alerts',
+					$toCommit
+				);
+
+				$success = true;
+			} catch (Exception $e) {
+			}
 		}
 
 		return $success;
@@ -404,7 +404,7 @@ class MybbStuff_MyAlerts_AlertManager
 	 *
 	 * @return int The total number of alerts the user has
 	 */
-	public function getNumAlerts()
+	public function getNumAlerts(): int
 	{
 		static $numAlerts;
 
@@ -438,11 +438,9 @@ SQL;
 	 *
 	 * @return string The formatted string of alert types enabled for the user.
 	 */
-	private function getAlertTypesForIn()
+	private function getAlertTypesForIn(): string
 	{
-		$alertTypes = implode(',', $this->currentUserEnabledAlerts);
-
-		return $alertTypes;
+		return implode(',', $this->currentUserEnabledAlerts);
 	}
 
 	/**
@@ -450,12 +448,12 @@ SQL;
 	 *
 	 * @return int The number of unread alerts
 	 */
-	public function getNumUnreadAlerts($force_recount = false)
+	public function getNumUnreadAlerts(bool $force_recount = false): int
 	{
 		static $numUnreadAlerts;
 
 		if (!is_int($numUnreadAlerts) || $force_recount) {
-			$numAlerts = 0;
+			$numUnreadAlerts = 0;
 
 			if (!empty($this->currentUserEnabledAlerts)) {
 				$alertTypes = $this->getAlertTypesForIn();
@@ -482,22 +480,19 @@ SQL;
 	}
 
 	/**
-	 *  Fetch all alerts for the currently logged in user
+	 *  Fetch all alerts for the currently logged-in user
 	 *
 	 * @param int $start The start point (used for multipaging alerts)
 	 * @param int $limit The maximum number of alerts to retrieve.
-	 * @param boolean $unreadOnly Whether to show only unread alerts.
+	 * @param bool $unreadOnly Whether to show only unread alerts.
 	 *
 	 * @return array The alerts for the user.
-	 * @return boolean If the user has no new alerts.
-	 * @throws Exception Thrown if the use cannot access the alerts system.
+	 * @return bool If the user has no new alerts.
+	 * @throws Exception Thrown if the use cannot access the alerts' system.
 	 */
-	public function getAlerts($start = 0, $limit = 0, $unreadOnly = false)
+	public function getAlerts(int $start = 0, int $limit = 0, bool $unreadOnly = false): array
 	{
 		$alerts = array();
-
-		$start = (int) $start;
-		$limit = (int) $limit;
 
 		if (!empty($this->currentUserEnabledAlerts)) {
 			if ($limit == 0) {
@@ -520,12 +515,12 @@ SQL;
 			$query = $this->db->write_query($alertsQuery);
 
 			if ($this->db->num_rows($query) > 0) {
-				$return = array();
 				while ($alertRow = $this->db->fetch_array($query)) {
-					$alertType = $this->alertTypeManager->getByCode(
-						$alertRow['code']
-					);
-					if ($alertType != null) {
+					try {
+						$alertType = $this->alertTypeManager->getByCode(
+							$alertRow['code']
+						);
+
 						$alert = new MybbStuff_MyAlerts_Entity_Alert(
 							$alertRow['uid'],
 							$alertType,
@@ -551,6 +546,8 @@ SQL;
 						$alert->setFromUser($user);
 
 						$alerts[] = $alert;
+					} catch (Exception $e) {
+
 					}
 				}
 			}
@@ -560,13 +557,13 @@ SQL;
 	}
 
 	/**
-	 *  Fetch all unread alerts for the currently logged in user.
+	 *  Fetch all unread alerts for the currently logged-in user.
 	 *
 	 * @return Array When the user has unread alerts.
-	 * @return boolean If the user has no new alerts.
-	 * @throws Exception Thrown if the use cannot access the alerts system.
+	 * @return bool If the user has no new alerts.
+	 * @throws Exception Thrown if the use cannot access the alerts' system.
 	 */
-	public function getUnreadAlerts()
+	public function getUnreadAlerts(): array
 	{
 		$alerts = array();
 
@@ -587,11 +584,11 @@ SQL;
 
 			if ($this->db->num_rows($query) > 0) {
 				while ($alertRow = $this->db->fetch_array($query)) {
-					$alertType = $this->alertTypeManager->getByCode(
-						$alertRow['code']
-					);
+					try {
+						$alertType = $this->alertTypeManager->getByCode(
+							$alertRow['code']
+						);
 
-					if ($alertType != null) {
 						$alert = new MybbStuff_MyAlerts_Entity_Alert(
 							$alertRow['uid'],
 							$alertType,
@@ -617,6 +614,8 @@ SQL;
 						$alert->setFromUser($user);
 
 						$alerts[] = $alert;
+					} catch (Exception $e) {
+
 					}
 				}
 			}
@@ -631,11 +630,10 @@ SQL;
 	 * @param int $id The ID of the alert to fetch.
 	 *
 	 * @return MybbSTuff_MyAlerts_Entity_Alert
+	 * @throws Exception
 	 */
-	public function getAlert($id = 0)
+	public function getAlert(int $id = 0): \MybbStuff_MyAlerts_Entity_Alert
 	{
-		$id = (int) $id;
-
 		$alert = null;
 
 		$this->mybb->user['uid'] = (int) $this->mybb->user['uid'];
@@ -651,11 +649,11 @@ SQL;
 
 		if ($this->db->num_rows($query) > 0) {
 			while ($alertRow = $this->db->fetch_array($query)) {
-				$alertType = $this->alertTypeManager->getByCode(
-					$alertRow['code']
-				);
+				try {
+					$alertType = $this->alertTypeManager->getByCode(
+						$alertRow['code']
+					);
 
-				if ($alertType != null) {
 					$alert = new MybbStuff_MyAlerts_Entity_Alert(
 						$alertRow['uid'],
 						$alertType,
@@ -677,19 +675,26 @@ SQL;
 					);
 
 					$alert->setFromUser($user);
+				} catch (Exception $e) {
+
 				}
 			}
+		}
+
+		if(!($alert instanceof MybbStuff_MyAlerts_Entity_Alert)) {
+			throw new Exception("Alert with ID {$id} not found.");
 		}
 
 		return $alert;
 	}
 
 	/**
-	 * Mark all alerts for the currently logged in user as read.
+	 * Mark all alerts for the currently logged-in user as read.
 	 *
 	 * @return bool Whether all alerts were marked read successfully.
 	 */
-	public function markAllRead() {
+	public function markAllRead(): bool
+	{
 		$success = (bool) $this->db->update_query(
 			'alerts',
 			array(
@@ -724,7 +729,7 @@ SQL;
 	 *
 	 * @return bool Whether the alerts were marked read successfully.
 	 */
-	public function markRead(array $alerts = array())
+	public function markRead(array $alerts = array()): bool
 	{
 		return $this->markReadOrUnread($alerts, true);
 	}
@@ -736,7 +741,7 @@ SQL;
 	 *
 	 * @return bool Whether the alerts were marked unread successfully.
 	 */
-	public function markUnread(array $alerts = array())
+	public function markUnread(array $alerts = array()): bool
 	{
 		return $this->markReadOrUnread($alerts, false);
 	}
@@ -749,13 +754,11 @@ SQL;
 	 *
 	 * @return bool Whether the alerts were marked read or unread successfully.
 	 */
-	public function markReadOrUnread(array $alerts = array(), $markRead = true)
+	public function markReadOrUnread(array $alerts = array(), $markRead = true): bool
 	{
-		$alerts = (array) $alerts;
-
 		$success = true;
 
-		if (is_array($alerts) && !empty($alerts)) {
+		if (!empty($alerts)) {
 			$alerts = array_map('intval', $alerts);
 			$alerts = "'" . implode("','", $alerts) . "'";
 
@@ -795,7 +798,7 @@ SQL;
 	 *
 	 * @return bool Whether the alerts were deleted successfully.
 	 */
-	public function deleteAlerts(array $alerts = array())
+	public function deleteAlerts(array $alerts = array()): bool
 	{
 		$success = false;
 

--- a/inc/plugins/MybbStuff/MyAlerts/src/Entity/Alert.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Entity/Alert.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * A single alert object as it's represented in the database.
  *
@@ -8,36 +10,36 @@
 class MybbStuff_MyAlerts_Entity_Alert
 {
 	/** @var int The ID of the alert. */
-	private $id = 0;
+	private int $id = 0;
 	/** @var array The details of the user that sent the alert. */
-	private $fromUser = array();
+	private array $fromUser = array();
 	/** @var int The ID of the user this alert is from. */
-	private $fromUserId;
+	private int $fromUserId;
 	/** @var int The ID of the user this alert is for. */
-	private $userId;
-	/** @var int|string The ID of the type of alert this is. */
-	private $typeId;
+	private int $userId;
+	/** @var int The ID of the type of alert this is. */
+	private int $typeId;
 	/** @var MybbSTuff_MyAlerts_Entity_AlertType The type of the alert. */
-	private $type = null;
+	private MybbSTuff_MyAlerts_Entity_AlertType $type;
 	/** @var int The ID of the object this alert is linked to. */
-	private $objectId = null;
-	/** @var \DateTime The date/time this alert was created at. */
-	private $createdAt;
+	private int $objectId;
+	/** @var DateTime The date/time this alert was created at. */
+	private DateTime $createdAt;
 	/** @var bool Whether the alert is unread. */
-	private $unread = true;
+	private bool $unread = true;
 	/** @var array Any extra details for the alert. */
-	private $extraDetails = array();
+	private array $extraDetails = array();
 
 	/**
-	 * Initialise a new Alert instance.
+	 * Initialize a new Alert instance.
 	 *
-	 * @param int|array                                      $user     The ID
+	 * @param int                                      $user     The ID
 	 *                                                                 of the
 	 *                                                                 user
 	 *                                                                 this
 	 *                                                                 alert is
 	 *                                                                 for.
-	 * @param int|MybbSTuff_MyAlerts_Entity_AlertType|string $type     The ID
+	 * @param MybbSTuff_MyAlerts_Entity_AlertType $type     The ID
 	 *                                                                 of the
 	 *                                                                 object
 	 *                                                                 this
@@ -56,62 +58,36 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *                                                                 linked
 	 *                                                                 to.
 	 */
-	public function __construct($user = 0, $type = 0, $objectId = null)
+	public function __construct(int $user, \MybbStuff_MyAlerts_Entity_AlertType $type, int $objectId = 0)
 	{
-		if (is_array($user)) {
-			$this->userId = (int) $user['uid'];
-		} else {
-			$this->userId = (int) $user;
+		$this->userId =  $user;
+
+		$this->setType($type);
+
+		if ($objectId) {
+			$this->objectId = $objectId;
 		}
 
-		if ($type instanceof MybbStuff_MyAlerts_Entity_AlertType) {
-			$this->setType($type);
-		} else {
-			$this->setTypeId($type);
-		}
-
-		if (isset($objectId)) {
-			$this->objectId = (int) $objectId;
-		}
-
-		$this->createdAt = new \DateTime();
+		$this->createdAt = new DateTime();
 	}
 
 	/**
 	 * Create an alert object with the given details.
 	 *
-	 * @param int|array                               $user         The ID of
-	 *                                                              the user
-	 *                                                              this alert
-	 *                                                              is for.
-	 * @param int|MybbStuff_MyAlerts_Entity_AlertType $type         The ID of
-	 *                                                              the object
-	 *                                                              this alert
-	 *                                                              is linked
-	 *                                                              to.
-	 * @param int                                     $objectId     The ID of
-	 *                                                              the object
-	 *                                                              this alert
-	 *                                                              is linked
-	 *                                                              to.
-	 * @param array                                   $extraDetails An array of
-	 *                                                              optional
-	 *                                                              extra
-	 *                                                              details to
-	 *                                                              be stored
-	 *                                                              with the
-	 *                                                              alert.
+	 * @param int $userID         The ID of the user this alert is for.
+	 * @param MybbStuff_MyAlerts_Entity_AlertType $type         The ID of the object this alert is linked to.
+	 * @param int $objectId     The ID of the object this alert is linked to.
+	 * @param array $extraDetails An array of optional extra details to be stored with the alert.
 	 *
 	 * @return MybbStuff_MyAlerts_Entity_Alert The created alert object.
 	 */
 	public static function make(
-		$user = 0,
-		$type = 0,
-		$objectId = null,
+		int $userID,
+		MybbStuff_MyAlerts_Entity_AlertType $type,
+		int $objectId = 0,
 		array $extraDetails = array()
-	) {
-		/** @var MybbStuff_MyAlerts_Entity_Alert $alert */
-		$alert = new static($user, $type, $objectId);
+	): MybbStuff_MyAlerts_Entity_Alert {
+		$alert = new static($userID, $type, $objectId);
 
 		$alert->setExtraDetails($extraDetails);
 
@@ -121,7 +97,7 @@ class MybbStuff_MyAlerts_Entity_Alert
 	/**
 	 * @return int
 	 */
-	public function getId()
+	public function getId():int
 	{
 		return $this->id;
 	}
@@ -131,9 +107,9 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *
 	 * @return MybbStuff_MyAlerts_Entity_Alert $this
 	 */
-	public function setId($id)
+	public function setId(int $id): MybbStuff_MyAlerts_Entity_Alert
 	{
-		$this->id = (int) $id;
+		$this->id = $id;
 
 		return $this;
 	}
@@ -144,7 +120,7 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *
 	 * @return array Array representation of the Alert.
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		return array(
 			'uid'           => $this->getUserId(),
@@ -160,9 +136,9 @@ class MybbStuff_MyAlerts_Entity_Alert
 	/**
 	 * @return int
 	 */
-	public function getUserId()
+	public function getUserId(): int
 	{
-		return (int) $this->userId;
+		return $this->userId;
 	}
 
 	/**
@@ -170,9 +146,9 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setUserId($userId)
+	public function setUserId(int $userId): MybbStuff_MyAlerts_Entity_Alert
 	{
-		$this->userId = (int) $userId;
+		$this->userId = $userId;
 
 		return $this;
 	}
@@ -180,27 +156,27 @@ class MybbStuff_MyAlerts_Entity_Alert
 	/**
 	 * @return int
 	 */
-	public function getFromUserId()
+	public function getFromUserId(): int
 	{
-		return (int) $this->fromUserId;
+		return $this->fromUserId;
 	}
 
 	/**
-	 * @param int $fromUserId The from user ID to set.
+	 * @param int $fromUserId The form user ID to set.
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setFromUserId($fromUserId)
+	public function setFromUserId(int $fromUserId): MybbStuff_MyAlerts_Entity_Alert
 	{
-		$this->fromUserId = (int) $fromUserId;
+		$this->fromUserId = $fromUserId;
 
 		return $this;
 	}
 
 	/**
-	 * @return int|string
+	 * @return int
 	 */
-	public function getTypeId()
+	public function getTypeId(): int
 	{
 		return $this->typeId;
 	}
@@ -210,9 +186,9 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setTypeId($typeId)
+	public function setTypeId(int $typeId): MybbStuff_MyAlerts_Entity_Alert
 	{
-		$this->typeId = (int) $typeId;
+		$this->typeId = $typeId;
 
 		return $this;
 	}
@@ -220,9 +196,9 @@ class MybbStuff_MyAlerts_Entity_Alert
 	/**
 	 * @return int
 	 */
-	public function getObjectId()
+	public function getObjectId(): int
 	{
-		return (int) $this->objectId;
+		return $this->objectId;
 	}
 
 	/**
@@ -230,27 +206,27 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setObjectId($objectId = 0)
+	public function setObjectId(int $objectId = 0): MybbStuff_MyAlerts_Entity_Alert
 	{
-		$this->objectId = (int) $objectId;
+		$this->objectId = $objectId;
 
 		return $this;
 	}
 
 	/**
-	 * @return \DateTime
+	 * @return DateTime
 	 */
-	public function getCreatedAt()
+	public function getCreatedAt(): DateTime
 	{
 		return $this->createdAt;
 	}
 
 	/**
-	 * @param \DateTime $createdAt The date the alert was created at.
+	 * @param DateTime $createdAt The date the alert was created at.
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setCreatedAt(DateTime $createdAt)
+	public function setCreatedAt(DateTime $createdAt): MybbStuff_MyAlerts_Entity_Alert
 	{
 		$this->createdAt = $createdAt;
 
@@ -260,7 +236,7 @@ class MybbStuff_MyAlerts_Entity_Alert
 	/**
 	 * @return array
 	 */
-	public function getExtraDetails()
+	public function getExtraDetails(): array
 	{
 		return $this->extraDetails;
 	}
@@ -270,7 +246,7 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setExtraDetails(array $extraDetails = array())
+	public function setExtraDetails(array $extraDetails = array()): MybbStuff_MyAlerts_Entity_Alert
 	{
 		$this->extraDetails = $extraDetails;
 
@@ -278,21 +254,21 @@ class MybbStuff_MyAlerts_Entity_Alert
 	}
 
 	/**
-	 * @return boolean
+	 * @return bool
 	 */
-	public function getUnread()
+	public function getUnread(): bool
 	{
-		return (boolean) $this->unread;
+		return $this->unread;
 	}
 
 	/**
-	 * @param boolean $unread Whether the alert is unread.
+	 * @param bool $unread Whether the alert is unread.
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setUnread($unread = true)
+	public function setUnread(bool $unread = true): MybbStuff_MyAlerts_Entity_Alert
 	{
-		$this->unread = (boolean) $unread;
+		$this->unread = $unread;
 
 		return $this;
 	}
@@ -300,7 +276,7 @@ class MybbStuff_MyAlerts_Entity_Alert
 	/**
 	 * @return MybbSTuff_MyAlerts_Entity_AlertType The type of alert this is.
 	 */
-	public function getType()
+	public function getType(): \MybbSTuff_MyAlerts_Entity_AlertType
 	{
 		return $this->type;
 	}
@@ -310,7 +286,7 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setType(MybbStuff_MyAlerts_Entity_AlertType $type)
+	public function setType(MybbStuff_MyAlerts_Entity_AlertType $type): MybbStuff_MyAlerts_Entity_Alert
 	{
 		$this->type = $type;
 		$this->setTypeId($type->getId());
@@ -321,7 +297,7 @@ class MybbStuff_MyAlerts_Entity_Alert
 	/**
 	 * Get the user who sent the alert's details.
 	 */
-	public function getFromUser()
+	public function getFromUser(): array
 	{
 		return $this->fromUser;
 	}
@@ -331,7 +307,7 @@ class MybbStuff_MyAlerts_Entity_Alert
 	 *
 	 * @return MybbStuff_Myalerts_Entity_Alert $this.
 	 */
-	public function setFromUser(array $user = array())
+	public function setFromUser(array $user = array()): MybbStuff_MyAlerts_Entity_Alert
 	{
 		$this->fromUser = $user;
 		$this->setFromUserId($user['uid']);

--- a/inc/plugins/MybbStuff/MyAlerts/src/Entity/AlertType.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Entity/AlertType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * A single alert type object as it's represented in the database.
  *
@@ -8,24 +10,24 @@
 class MybbStuff_MyAlerts_Entity_AlertType
 {
 	/** @var int The ID of the alert type. */
-	private $id = 0;
+	private int $id = 0;
 	/** @var string The short code identifying the alert type - eg: 'pm', 'rep'. */
-	private $code = '';
+	private string $code = '';
 	/** @var bool Whether the alert type is enabled. */
-	private $enabled = true;
+	private bool $enabled = true;
 	/** @var bool Whether this alert type can be disabled by users. */
-	private $canBeUserDisabled = true;
+	private bool $canBeUserDisabled = true;
 	/** @var bool Whether this alert type is enabled for users by default. */
-	private $defaultUserEnabled = true;
+	private bool $defaultUserEnabled = true;
 
 	/**
 	 * Unserialize an alert type from an array created using toArray().
 	 *
 	 * @param array $serialized The serialized alert type.
 	 *
-	 * @return MybbStuff_MyAlerts_Entity_AlertType The unserialized alert type.
+	 * @return MybbStuff_MyAlerts_Entity_AlertType The unserialised alert type.
 	 */
-	public static function unserialize(array $serialized)
+	public static function unserialize(array $serialized): MybbStuff_MyAlerts_Entity_AlertType
 	{
 		$serialized = array_merge(
 			array(
@@ -51,9 +53,9 @@ class MybbStuff_MyAlerts_Entity_AlertType
 	/**
 	 * Serialize the alert type to an array.
 	 *
-	 * @return array The seralized alert type.
+	 * @return array The serialized alert type.
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		return array(
 			'id'                   => $this->getId(),
@@ -67,7 +69,7 @@ class MybbStuff_MyAlerts_Entity_AlertType
 	/**
 	 * @return int
 	 */
-	public function getId()
+	public function getId(): int
 	{
 		return $this->id;
 	}
@@ -77,9 +79,9 @@ class MybbStuff_MyAlerts_Entity_AlertType
 	 *
 	 * @return MybbStuff_Myalerts_Entity_AlertType $this.
 	 */
-	public function setId($id = 0)
+	public function setId(int $id = 0): MybbStuff_Myalerts_Entity_AlertType
 	{
-		$this->id = (int) $id;
+		$this->id = $id;
 
 		return $this;
 	}
@@ -87,7 +89,7 @@ class MybbStuff_MyAlerts_Entity_AlertType
 	/**
 	 * @return string
 	 */
-	public function getCode()
+	public function getCode(): string
 	{
 		return $this->code;
 	}
@@ -97,71 +99,71 @@ class MybbStuff_MyAlerts_Entity_AlertType
 	 *
 	 * @return MybbStuff_Myalerts_Entity_AlertType $this.
 	 */
-	public function setCode($code)
+	public function setCode(string $code): static
 	{
-		$this->code = (string) $code;
+		$this->code = $code;
 
 		return $this;
 	}
 
 	/**
-	 * @return boolean
+	 * @return bool
 	 */
-	public function getEnabled()
+	public function getEnabled(): bool
 	{
 		return $this->enabled;
 	}
 
 	/**
-	 * @param boolean $enabled Whether the alert type is enabled.
+	 * @param bool $enabled Whether the alert type is enabled.
 	 *
 	 * @return MybbStuff_Myalerts_Entity_AlertType $this.
 	 */
-	public function setEnabled($enabled = true)
+	public function setEnabled(bool $enabled = true): static
 	{
-		$this->enabled = (bool) $enabled;
+		$this->enabled = $enabled;
 
 		return $this;
 	}
 
 	/**
-	 * @return boolean Whether this alert type can be disabled by users.
+	 * @return bool Whether this alert type can be disabled by users.
 	 */
-	public function getCanBeUserDisabled()
+	public function getCanBeUserDisabled(): bool
 	{
 		return $this->canBeUserDisabled;
 	}
 
 	/**
-	 * @return boolean Whether this alert type is enabled for users by default.
+	 * @return bool Whether this alert type is enabled for users by default.
 	 */
-	public function getDefaultUserEnabled()
+	public function getDefaultUserEnabled(): bool
 	{
 		return $this->defaultUserEnabled;
 	}
 
 	/**
-	 * @param boolean $canBeUserDisabled Whether this alert type can be
+	 * @param bool $canBeUserDisabled Whether this alert type can be
 	 *                                   disabled by users.
 	 *
 	 * @return $this
 	 */
-	public function setCanBeUserDisabled($canBeUserDisabled = true)
+	public function setCanBeUserDisabled(bool $canBeUserDisabled = true): MybbStuff_MyAlerts_Entity_AlertType
 	{
-		$this->canBeUserDisabled = (bool) $canBeUserDisabled;
+		$this->canBeUserDisabled = $canBeUserDisabled;
 
 		return $this;
 	}
 
 	/**
-	 * @param boolean $defaultUserEnabled Whether this alert type is
+	 * @param bool $defaultUserEnabled Whether this alert type is
 	 *                                   enabled for users by default.
 	 *
 	 * @return $this
 	 */
-	public function setDefaultUserEnabled($defaultUserEnabled = true)
+	public function setDefaultUserEnabled(bool $defaultUserEnabled = true): MybbStuff_MyAlerts_Entity_AlertType
 	{
-		$this->defaultUserEnabled = (bool) $defaultUserEnabled;
+		$this->defaultUserEnabled = $defaultUserEnabled;
 
 		return $this;
 	}

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/AbstractFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/AbstractFormatter.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Base alert formatter. Alert type formatters should inherit from this base
- * class in order to have alerts displayed correctly.
+ * class to have alerts displayed correctly.
  *
  * @package MybbStuff\MyAlerts
  */
@@ -11,18 +13,18 @@ abstract class MybbStuff_MyAlerts_Formatter_AbstractFormatter
 	/**
 	 * @var MyBB
 	 */
-	protected $mybb;
+	protected MyBB $mybb;
 	/**
 	 * @var MyLanguage
 	 */
-	protected $lang;
+	protected MyLanguage $lang;
 	/**
 	 * @var string
 	 */
-	protected $alertTypeName;
+	protected string $alertTypeName;
 
 	/**
-	 * Initialise a new alert formatter.
+	 * Initialize a new alert formatter.
 	 *
 	 * @param MyBB       $mybb An instance of the MyBB core class to use when
 	 *                         formatting.
@@ -32,17 +34,17 @@ abstract class MybbStuff_MyAlerts_Formatter_AbstractFormatter
 	public function __construct(
 		MyBB &$mybb,
 		MyLanguage &$lang,
-		$alertTypeName = ''
+		string $alertTypeName = ''
 	) {
 		$this->mybb = $mybb;
 		$this->lang = $lang;
-		$this->alertTypeName = (string) $alertTypeName;
+		$this->alertTypeName = $alertTypeName;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getAlertTypeName()
+	public function getAlertTypeName(): string
 	{
 		return $this->alertTypeName;
 	}
@@ -50,15 +52,15 @@ abstract class MybbStuff_MyAlerts_Formatter_AbstractFormatter
 	/**
 	 * @param string $alertTypeName
 	 */
-	public function setAlertTypeName($alertTypeName = '')
+	public function setAlertTypeName(string $alertTypeName = ''): void
 	{
-		$this->alertTypeName = (string) $alertTypeName;
+		$this->alertTypeName = $alertTypeName;
 	}
 
 	/**
 	 * @return MyLanguage
 	 */
-	public function getLang()
+	public function getLang(): MyLanguage
 	{
 		return $this->lang;
 	}
@@ -66,7 +68,7 @@ abstract class MybbStuff_MyAlerts_Formatter_AbstractFormatter
 	/**
 	 * @param MyLanguage $lang
 	 */
-	public function setLang(MyLanguage $lang)
+	public function setLang(MyLanguage $lang): void
 	{
 		$this->lang = $lang;
 	}
@@ -74,7 +76,7 @@ abstract class MybbStuff_MyAlerts_Formatter_AbstractFormatter
 	/**
 	 * @return MyBB
 	 */
-	public function getMybb()
+	public function getMybb(): MyBB
 	{
 		return $this->mybb;
 	}
@@ -82,7 +84,7 @@ abstract class MybbStuff_MyAlerts_Formatter_AbstractFormatter
 	/**
 	 * @param MyBB $mybb
 	 */
-	public function setMybb(MyBB $mybb)
+	public function setMybb(MyBB $mybb): void
 	{
 		$this->mybb = $mybb;
 	}
@@ -93,37 +95,31 @@ abstract class MybbStuff_MyAlerts_Formatter_AbstractFormatter
 	 *
 	 * @return void
 	 */
-	public abstract function init();
+	abstract public function init(): void;
 
 	/**
 	 * Format an alert into it's output string to be used in both the main
 	 * alerts listing page and the popup.
 	 *
 	 * @param MybbStuff_MyAlerts_Entity_Alert $alert       The alert to format.
-	 * @param array                           $outputAlert The alert output
-	 *                                                     details, including
-	 *                                                     formated from user
-	 *                                                     name, from user
-	 *                                                     profile link and
-	 *                                                     more.
+	 * @param array $outputAlert The alert output details, including formated from username, from user profile link and more.
 	 *
 	 * @return string The formatted alert string.
 	 */
-	public abstract function formatAlert(
+	abstract public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	);
+	): string;
 
 	/**
 	 * Build a link to an alert's content so that the system can redirect to
 	 * it.
 	 *
-	 * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the
-	 *                                               link for.
+	 * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the link for.
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public abstract function buildShowLink(
+	abstract public function buildShowLink(
 		MybbStuff_MyAlerts_Entity_Alert $alert
-	);
+	): string;
 }

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/BuddylistFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/BuddylistFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Alert formatter for buddy list alerts.
  */
@@ -17,7 +19,8 @@ class MybbStuff_MyAlerts_Formatter_BuddylistFormatter
 	public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	) {
+	): string
+	{
 		return $this->lang->sprintf(
 			$this->lang->myalerts_buddylist,
 			$outputAlert['from_user']
@@ -30,7 +33,7 @@ class MybbStuff_MyAlerts_Formatter_BuddylistFormatter
 	 *
 	 * @return void
 	 */
-	public function init()
+	public function init(): void
 	{
 		if (!$this->lang->myalerts) {
 			$this->lang->load('myalerts');
@@ -46,7 +49,7 @@ class MybbStuff_MyAlerts_Formatter_BuddylistFormatter
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert): string
 	{
 		return get_profile_link($alert->getFromUserId());
 	}

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/PrivateMessageFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/PrivateMessageFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Alert formatter for private message (PM) alerts.
  */
@@ -9,7 +11,7 @@ class MybbStuff_MyAlerts_Formatter_PrivateMessageFormatter
 	/**
 	 * @var postParser $parser
 	 */
-	private $parser;
+	private postParser $parser;
 
 	/**
 	 * Format an alert into it's output string to be used in both the main
@@ -22,7 +24,8 @@ class MybbStuff_MyAlerts_Formatter_PrivateMessageFormatter
 	public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	) {
+	): string
+	{
 		$alertContent = $alert->getExtraDetails();
 
 		$pmSubject = htmlspecialchars_uni(
@@ -42,14 +45,14 @@ class MybbStuff_MyAlerts_Formatter_PrivateMessageFormatter
 	 *
 	 * @return void
 	 */
-	public function init()
+	public function init(): void
 	{
 		if (!$this->lang->myalerts) {
 			$this->lang->load('myalerts');
 		}
 
 		require_once MYBB_ROOT . 'inc/class_parser.php';
-		$this->parser = new postParser;
+		$this->parser = new postParser();
 	}
 
 	/**
@@ -61,7 +64,7 @@ class MybbStuff_MyAlerts_Formatter_PrivateMessageFormatter
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert): string
 	{
 		$pmId = $alert->getObjectId();
 

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/QuotedFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/QuotedFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Alert formatter for quote alerts.
  */
@@ -9,7 +11,7 @@ class MybbStuff_MyAlerts_Formatter_QuotedFormatter
 	/**
 	 * @var postParser $parser
 	 */
-	private $parser;
+	private postParser $parser;
 
 	/**
 	 * Format an alert into it's output string to be used in both the main
@@ -22,9 +24,9 @@ class MybbStuff_MyAlerts_Formatter_QuotedFormatter
 	public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	) {
+	): string
+	{
 		$alertContent = $alert->getExtraDetails();
-		$postLink = $this->buildShowLink($alert);
 
 		return $this->lang->sprintf(
 			$this->lang->myalerts_quoted,
@@ -41,14 +43,14 @@ class MybbStuff_MyAlerts_Formatter_QuotedFormatter
 	 *
 	 * @return void
 	 */
-	public function init()
+	public function init(): void
 	{
 		if (!$this->lang->myalerts) {
 			$this->lang->load('myalerts');
 		}
 
 		require_once MYBB_ROOT . 'inc/class_parser.php';
-		$this->parser = new postParser;
+		$this->parser = new postParser();
 	}
 
 	/**
@@ -60,14 +62,13 @@ class MybbStuff_MyAlerts_Formatter_QuotedFormatter
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert): string
 	{
 		$alertContent = $alert->getExtraDetails();
-		$postLink = $this->mybb->settings['bburl'] . '/' . get_post_link(
+
+		return $this->mybb->settings['bburl'] . '/' . get_post_link(
 				(int) $alertContent['pid'],
 				(int) $alertContent['tid']
 			) . '#pid' . (int) $alertContent['pid'];
-
-		return $postLink;
 	}
 }

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/RepFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/RepFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Alert formatter for reputation alerts.
  */
@@ -17,7 +19,8 @@ class MybbStuff_MyAlerts_Formatter_RepFormatter
 	public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	) {
+	): string
+	{
 		return $this->lang->sprintf(
 			$this->lang->myalerts_rep,
 			$outputAlert['from_user']
@@ -30,7 +33,7 @@ class MybbStuff_MyAlerts_Formatter_RepFormatter
 	 *
 	 * @return void
 	 */
-	public function init()
+	public function init(): void
 	{
 		if (!$this->lang->myalerts) {
 			$this->lang->load('myalerts');
@@ -41,12 +44,11 @@ class MybbStuff_MyAlerts_Formatter_RepFormatter
 	 * Build a link to an alert's content so that the system can redirect to
 	 * it.
 	 *
-	 * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the
-	 *                                               link for.
+	 * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the link for.
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert): string
 	{
 		return "{$this->mybb->settings['bburl']}/reputation.php?uid={$this->mybb->user['uid']}";
 

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/SubscribedThreadFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/SubscribedThreadFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Alert formatter for subscribed thread alerts.
  */
@@ -17,7 +19,8 @@ class MybbStuff_MyAlerts_Formatter_SubscribedThreadFormatter
 	public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	) {
+	): string
+	{
 		$alertContent = $alert->getExtraDetails();
 
 		return $this->lang->sprintf(
@@ -33,7 +36,7 @@ class MybbStuff_MyAlerts_Formatter_SubscribedThreadFormatter
 	 *
 	 * @return void
 	 */
-	public function init()
+	public function init(): void
 	{
 		if (!$this->lang->myalerts) {
 			$this->lang->load('myalerts');
@@ -49,16 +52,14 @@ class MybbStuff_MyAlerts_Formatter_SubscribedThreadFormatter
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert): string
 	{
 		$alertContent = $alert->getExtraDetails();
 
-		$threadLink = $this->mybb->settings['bburl'] . '/' . get_thread_link(
+		return $this->mybb->settings['bburl'] . '/' . get_thread_link(
 				(int) $alertContent['tid'],
 				0,
 				'newpost'
 			);
-
-		return $threadLink;
 	}
 }

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/ThreadAuthorRatedFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/ThreadAuthorRatedFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Alert formatter for private thread author rate alerts.
  */
@@ -9,7 +11,7 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorRatedFormatter
 	/**
 	 * @var postParser $parser
 	 */
-	private $parser;
+	private postParser $parser;
 
 	/**
 	 * Format an alert into it's output string to be used in both the main
@@ -22,9 +24,9 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorRatedFormatter
 	public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	) {
+	): string
+	{
 		$alertContent = $alert->getExtraDetails();
-		$threadLink = $this->buildShowLink($alert);
 
 		return $this->lang->sprintf(
 			$this->lang->myalerts_rated_threadauthor,
@@ -41,14 +43,14 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorRatedFormatter
 	 *
 	 * @return void
 	 */
-	public function init()
+	public function init(): void
 	{
 		if (!$this->lang->myalerts) {
 			$this->lang->load('myalerts');
 		}
 
 		require_once MYBB_ROOT . 'inc/class_parser.php';
-		$this->parser = new postParser;
+		$this->parser = new postParser();
 	}
 
 	/**
@@ -60,14 +62,12 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorRatedFormatter
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert): string
 	{
 		$alertContent = $alert->getExtraDetails();
 
-		$threadLink = $this->mybb->settings['bburl'] . '/' . get_thread_link(
+		return $this->mybb->settings['bburl'] . '/' . get_thread_link(
 				(int) $alertContent['tid']
 			);
-
-		return $threadLink;
 	}
 }

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/ThreadAuthorReplyFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/ThreadAuthorReplyFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Alert formatter for private thread author reply alerts.
  */
@@ -9,7 +11,7 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorReplyFormatter
 	/**
 	 * @var postParser $parser
 	 */
-	private $parser;
+	private postParser $parser;
 
 	/**
 	 * Format an alert into it's output string to be used in both the main
@@ -22,9 +24,9 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorReplyFormatter
 	public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	) {
+	): string
+	{
 		$alertContent = $alert->getExtraDetails();
-		$threadLink = $this->buildShowLink($alert);
 
 		return $this->lang->sprintf(
 			$this->lang->myalerts_post_threadauthor,
@@ -41,35 +43,32 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorReplyFormatter
 	 *
 	 * @return void
 	 */
-	public function init()
+	public function init(): void
 	{
 		if (!$this->lang->myalerts) {
 			$this->lang->load('myalerts');
 		}
 
 		require_once MYBB_ROOT . 'inc/class_parser.php';
-		$this->parser = new postParser;
+		$this->parser = new postParser();
 	}
 
 	/**
 	 * Build a link to an alert's content so that the system can redirect to
 	 * it.
 	 *
-	 * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the
-	 *                                               link for.
+	 * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the link for.
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert): string
 	{
 		$alertContent = $alert->getExtraDetails();
 
-		$threadLink = $this->mybb->settings['bburl'] . '/' . get_thread_link(
+		return $this->mybb->settings['bburl'] . '/' . get_thread_link(
 				(int) $alertContent['tid'],
 				0,
 				'newpost'
 			);
-
-		return $threadLink;
 	}
 }

--- a/inc/plugins/MybbStuff/MyAlerts/src/Formatter/ThreadAuthorVotedFormatter.php
+++ b/inc/plugins/MybbStuff/MyAlerts/src/Formatter/ThreadAuthorVotedFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Alert formatter for private thread author vote alerts.
  */
@@ -9,7 +11,7 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorVotedFormatter
 	/**
 	 * @var postParser $parser
 	 */
-	private $parser;
+	private postParser $parser;
 
 	/**
 	 * Format an alert into it's output string to be used in both the main
@@ -22,9 +24,9 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorVotedFormatter
 	public function formatAlert(
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
-	) {
+	): string
+	{
 		$alertContent = $alert->getExtraDetails();
-		$threadLink = $this->buildShowLink($alert);
 
 		return $this->lang->sprintf(
 			$this->lang->myalerts_voted_threadauthor,
@@ -41,33 +43,30 @@ class MybbStuff_MyAlerts_Formatter_ThreadAuthorVotedFormatter
 	 *
 	 * @return void
 	 */
-	public function init()
+	public function init(): void
 	{
 		if (!$this->lang->myalerts) {
 			$this->lang->load('myalerts');
 		}
 
 		require_once MYBB_ROOT . 'inc/class_parser.php';
-		$this->parser = new postParser;
+		$this->parser = new postParser();
 	}
 
 	/**
 	 * Build a link to an alert's content so that the system can redirect to
 	 * it.
 	 *
-	 * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the
-	 *                                               link for.
+	 * @param MybbStuff_MyAlerts_Entity_Alert $alert The alert to build the link for.
 	 *
 	 * @return string The built alert, preferably an absolute link.
 	 */
-	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert)
+	public function buildShowLink(MybbStuff_MyAlerts_Entity_Alert $alert): string
 	{
 		$alertContent = $alert->getExtraDetails();
 
-		$threadLink = $this->mybb->settings['bburl'] . '/' . get_thread_link(
+		return $this->mybb->settings['bburl'] . '/' . get_thread_link(
 				(int) $alertContent['tid']
 			);
-
-		return $threadLink;
 	}
 }

--- a/inc/tasks/myalerts.php
+++ b/inc/tasks/myalerts.php
@@ -8,11 +8,13 @@
  * @package MyAlerts
  */
 
+declare(strict_types=1);
+
 if (!defined('IN_MYBB')) {
 	die('Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.');
 }
 
-function task_myalerts($task)
+function task_myalerts(array $task): void
 {
 	global $db, $lang;
 


### PR DESCRIPTION
With the intention to standardize the MyAlerts plugin and get it ready for 1.9, I suggest the following changes:

- [x] Implement type hints
- [x] Implement return types (avoid union types for now)
- [ ] Update functions and methods arguments names for PHP8.4 named arguments
- [ ] Implement exception handling
- [ ] Implement PSR12 as coding style

Discuss and feedback welcome.